### PR TITLE
fix(sync): sync_hash generation produces 12 characters instead of 8

### DIFF
--- a/plugins/sync/src/core/sync-engine.ts
+++ b/plugins/sync/src/core/sync-engine.ts
@@ -250,7 +250,7 @@ export class SyncEngine {
       .createHash('sha256')
       .update(mainFile.markdown)
       .digest('hex')
-      .substring(0, 8)
+      .substring(0, 12)
 
     // Update frontmatter
     if (!mainFile.frontmatter.github) {

--- a/plugins/sync/test/core/sync-engine.test.ts
+++ b/plugins/sync/test/core/sync-engine.test.ts
@@ -363,8 +363,8 @@ describe('SyncEngine', () => {
       const syncHash = specFile?.frontmatter.sync_hash
 
       expect(syncHash).toBeDefined()
-      expect(syncHash).toHaveLength(8)
-      expect(syncHash).toMatch(/^[a-f0-9]{8}$/)
+      expect(syncHash).toHaveLength(12)
+      expect(syncHash).toMatch(/^[a-f0-9]{12}$/)
     })
 
     test('should set current timestamp for last_sync', async () => {


### PR DESCRIPTION
Fixes #31

## Summary
Fixed the sync_hash generation to produce 12 hexadecimal characters as required by the schema validation.

## Changes
- Changed substring parameter from 8 to 12 in sync-engine.ts
- Updated test expectations to match 12-character hash requirement
- Fixes validation error with schema requiring /^[a-f0-9]{12}$/

## Test Results
- All 164 tests passing
- Linting and type checking successful

Generated with [Claude Code](https://claude.ai/code)