### PR TITLE
refactor: mark tracker member as readonly in LiveDisplay class

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -18,7 +18,7 @@ import { PlatformUtils } from '../utils/Platform.js'
 // Live update helper for step tracker
 class LiveDisplay {
   private intervalId?: NodeJS.Timeout
-  private tracker: StepTracker
+  private readonly tracker: StepTracker
 
   constructor(tracker: StepTracker) {
     this.tracker = tracker

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -18,11 +18,8 @@ import { PlatformUtils } from '../utils/Platform.js'
 // Live update helper for step tracker
 class LiveDisplay {
   private intervalId?: NodeJS.Timeout
-  private readonly tracker: StepTracker
 
-  constructor(tracker: StepTracker) {
-    this.tracker = tracker
-  }
+  constructor(private readonly tracker: StepTracker) {}
 
   start(): void {
     // Print initial state


### PR DESCRIPTION
Fixes #43

## Summary

Fixed SonarCloud code quality issue by marking the `tracker` member as readonly. This member is only assigned once in the constructor and never reassigned, so it should be marked as readonly for better type safety and code clarity.

## Changes
- Added `readonly` modifier to `tracker` member in `LiveDisplay` class

Generated with [Claude Code](https://claude.ai/code)