### PR TITLE
feat(sync): implement UUID generation and handling for spec files

### DIFF
--- a/example/specs/001-test-feature/spec.md
+++ b/example/specs/001-test-feature/spec.md
@@ -1,9 +1,9 @@
 ---
+sync_hash: 4a50de224c61
+last_sync: '2025-09-17T16:17:05.344Z'
+sync_status: synced
 github:
   issue_number: 3
-sync_status: synced
-last_sync: '2025-09-15T21:02:34.379Z'
-sync_hash: 4a50de220123
 ---
 # Feature 1
 

--- a/plugins/sync/src/adapters/github/uuid-utils.ts
+++ b/plugins/sync/src/adapters/github/uuid-utils.ts
@@ -4,7 +4,7 @@
 
 const UUID_COMMENT_REGEX = /<!--\s*spec_id:\s*([a-f0-9-]{36})\s*-->/i
 const UUID_COMMENT_REMOVE_REGEX = /<!--\s*spec_id:\s*[a-f0-9-]{36}\s*-->\s*/gi
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 /**
  * Embeds a UUID in an issue body as hidden HTML comment metadata.
@@ -41,7 +41,7 @@ export function extractUuidFromIssueBody(body: string): string | null {
 
 /**
  * Validates if a string is a valid UUID format.
- * Checks for UUID v4 format: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
+ * Checks for standard UUID format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
  *
  * @param uuid - The string to validate
  * @returns True if valid UUID format, false otherwise

--- a/plugins/sync/src/adapters/github/uuid-utils.ts
+++ b/plugins/sync/src/adapters/github/uuid-utils.ts
@@ -1,0 +1,71 @@
+/**
+ * UUID metadata utilities for GitHub issue body embedding
+ */
+
+const UUID_COMMENT_REGEX = /<!--\s*spec_id:\s*([a-f0-9-]{36})\s*-->/i
+const UUID_COMMENT_REMOVE_REGEX = /<!--\s*spec_id:\s*[a-f0-9-]{36}\s*-->\s*/gi
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+/**
+ * Embeds a UUID in an issue body as hidden HTML comment metadata.
+ * The UUID is embedded at the beginning of the body in the format:
+ * <!-- spec_id: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx -->
+ *
+ * @param body - The issue body content
+ * @param uuid - The UUID to embed
+ * @returns The body with embedded UUID metadata
+ * @throws Error if UUID format is invalid
+ */
+export function embedUuidInIssueBody(body: string, uuid: string): string {
+  if (!isValidUuid(uuid)) {
+    throw new Error(`Invalid UUID format: ${uuid}`)
+  }
+
+  // Remove existing UUID comment if present
+  const cleanBody = body.replace(UUID_COMMENT_REMOVE_REGEX, '').trim()
+
+  // Add UUID comment at the beginning
+  return `<!-- spec_id: ${uuid} -->\n\n${cleanBody}`
+}
+
+/**
+ * Extracts a UUID from an issue body that was previously embedded as metadata.
+ *
+ * @param body - The issue body content to search
+ * @returns The extracted UUID string, or null if not found
+ */
+export function extractUuidFromIssueBody(body: string): string | null {
+  const match = body.match(UUID_COMMENT_REGEX)
+  return match ? match[1] || null : null
+}
+
+/**
+ * Validates if a string is a valid UUID format.
+ * Checks for UUID v4 format: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
+ *
+ * @param uuid - The string to validate
+ * @returns True if valid UUID format, false otherwise
+ */
+export function isValidUuid(uuid: string): boolean {
+  return UUID_REGEX.test(uuid)
+}
+
+/**
+ * Checks if an issue body contains UUID metadata.
+ *
+ * @param body - The issue body content to check
+ * @returns True if UUID metadata is found, false otherwise
+ */
+export function hasUuidMetadata(body: string): boolean {
+  return UUID_COMMENT_REGEX.test(body)
+}
+
+/**
+ * Removes UUID metadata from an issue body.
+ *
+ * @param body - The issue body content
+ * @returns The body with UUID metadata removed
+ */
+export function removeUuidFromIssueBody(body: string): string {
+  return body.replace(UUID_COMMENT_REMOVE_REGEX, '').replace(/\n\s*\n\s*\n/g, '\n\n').trim()
+}

--- a/plugins/sync/test/adapters/github-uuid.test.ts
+++ b/plugins/sync/test/adapters/github-uuid.test.ts
@@ -1,0 +1,445 @@
+import type { SpecDocument, SpecFile, SpecFileFrontmatter } from '../../src/types'
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+import { GitHubAdapter } from '../../src/adapters/github/github.adapter'
+
+// Mock dependencies
+mock.module('../../src/adapters/github/api', () => ({
+  GitHubClient: mock().mockImplementation(() => ({
+    checkAuth: mock().mockResolvedValue(true),
+    searchIssueByUuid: mock(),
+    getIssue: mock(),
+    createIssue: mock(),
+    updateIssue: mock(),
+    ensureLabelsExist: mock(),
+    batchUpdateIssues: mock(),
+  })),
+}))
+
+mock.module('../../src/adapters/github/mapper', () => ({
+  SpecToIssueMapper: mock().mockImplementation(() => ({
+    generateTitle: mock().mockReturnValue('Test Issue Title'),
+    generateBody: mock().mockReturnValue('Test issue body content'),
+    issueToSpec: mock(),
+  })),
+}))
+
+describe('GitHubAdapter UUID Matching', () => {
+  let adapter: GitHubAdapter
+  let mockClient: any
+  let mockMapper: any
+
+  const validUuid = '550e8400-e29b-41d4-a716-446655440000'
+  const anotherUuid = 'f47ac10b-58cc-4372-a567-0e02b2c3d479'
+
+  const createMockSpec = (overrides: Partial<{
+    uuid: string
+    issueNumber: number
+    content: string
+  }> = {}): SpecDocument => {
+    const frontmatter: SpecFileFrontmatter = {
+      spec_id: overrides.uuid,
+      sync_status: 'draft',
+      github: overrides.issueNumber ? { issue_number: overrides.issueNumber } : undefined,
+    }
+
+    const specFile: SpecFile = {
+      path: '/test/spec.md',
+      filename: 'spec.md',
+      content: overrides.content || 'Test content',
+      frontmatter,
+      markdown: overrides.content || 'Test content',
+    }
+
+    return {
+      path: '/test/001-test-feature',
+      name: '001-test-feature',
+      issueNumber: overrides.issueNumber,
+      files: new Map([['spec.md', specFile]]),
+    }
+  }
+
+  const createMockIssue = (number: number, body: string) => ({
+    number,
+    title: 'Test Issue',
+    body,
+    state: 'open',
+    labels: [],
+  })
+
+  beforeEach(() => {
+    // Reset all mocks
+    mock.restore()
+
+    // Create fresh adapter instance
+    adapter = new GitHubAdapter({
+      owner: 'test-owner',
+      repo: 'test-repo',
+    })
+
+    // Get mock instances
+    mockClient = (adapter as any).client
+    mockMapper = (adapter as any).mapper
+
+    // Reset mock implementations
+    mockClient.checkAuth.mockResolvedValue(true)
+    mockClient.searchIssueByUuid.mockResolvedValue(null)
+    mockClient.getIssue.mockResolvedValue(null)
+    mockClient.createIssue.mockResolvedValue(123)
+    mockClient.updateIssue.mockResolvedValue(undefined)
+    mockClient.ensureLabelsExist.mockResolvedValue(undefined)
+
+    mockMapper.generateTitle.mockReturnValue('Test Issue Title')
+    mockMapper.generateBody.mockReturnValue('Test issue body content')
+  })
+
+  describe('push with UUID priority', () => {
+    test('uses UUID for matching when available', async () => {
+      const spec = createMockSpec({ uuid: validUuid })
+      const existingIssue = createMockIssue(456, `<!-- spec_id: ${validUuid} -->\n\nExisting content`)
+
+      mockClient.searchIssueByUuid.mockResolvedValue(existingIssue)
+
+      const result = await adapter.push(spec)
+
+      expect(mockClient.searchIssueByUuid).toHaveBeenCalledWith(validUuid)
+      expect(mockClient.updateIssue).toHaveBeenCalledWith(
+        456,
+        expect.objectContaining({
+          title: expect.any(String),
+          body: expect.stringContaining(validUuid),
+        }),
+      )
+      expect(result.id).toBe(456)
+    })
+
+    test('falls back to issue_number when UUID search fails', async () => {
+      const spec = createMockSpec({ uuid: validUuid, issueNumber: 789 })
+      const existingIssueByNumber = createMockIssue(789, 'Existing content without UUID')
+
+      mockClient.searchIssueByUuid.mockResolvedValue(null)
+      mockClient.getIssue.mockResolvedValue(existingIssueByNumber)
+
+      const result = await adapter.push(spec)
+
+      expect(mockClient.searchIssueByUuid).toHaveBeenCalledWith(validUuid)
+      expect(mockClient.getIssue).toHaveBeenCalledWith(789)
+      expect(mockClient.updateIssue).toHaveBeenCalledWith(
+        789,
+        expect.objectContaining({
+          title: expect.any(String),
+          body: expect.stringContaining(validUuid),
+        }),
+      )
+      expect(result.id).toBe(789)
+    })
+
+    test('detects UUID mismatch conflicts', async () => {
+      const spec = createMockSpec({ uuid: validUuid, issueNumber: 789 })
+      const existingIssueWithDifferentUuid = createMockIssue(
+        789,
+        `<!-- spec_id: ${anotherUuid} -->\n\nExisting content`,
+      )
+
+      mockClient.searchIssueByUuid.mockResolvedValue(null)
+      mockClient.getIssue.mockResolvedValue(existingIssueWithDifferentUuid)
+
+      await expect(adapter.push(spec)).rejects.toThrow('UUID mismatch')
+
+      expect(mockClient.searchIssueByUuid).toHaveBeenCalledWith(validUuid)
+      expect(mockClient.getIssue).toHaveBeenCalledWith(789)
+      expect(mockClient.updateIssue).not.toHaveBeenCalled()
+    })
+
+    test('creates new issue with UUID metadata', async () => {
+      const spec = createMockSpec({ uuid: validUuid })
+
+      mockClient.searchIssueByUuid.mockResolvedValue(null)
+      mockClient.getIssue.mockResolvedValue(null)
+      mockClient.createIssue.mockResolvedValue(999)
+
+      const result = await adapter.push(spec)
+
+      expect(mockClient.createIssue).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining(validUuid),
+        expect.any(Array),
+      )
+      expect(result.id).toBe(999)
+    })
+
+    test('updates existing issue preserving UUID', async () => {
+      const spec = createMockSpec({ uuid: validUuid, content: 'Updated content' })
+      const existingIssue = createMockIssue(456, `<!-- spec_id: ${validUuid} -->\n\nOld content`)
+
+      mockClient.searchIssueByUuid.mockResolvedValue(existingIssue)
+
+      await adapter.push(spec)
+
+      expect(mockClient.updateIssue).toHaveBeenCalledWith(
+        456,
+        expect.objectContaining({
+          body: expect.stringMatching(new RegExp(`<!-- spec_id: ${validUuid} -->`)),
+        }),
+      )
+    })
+
+    test('handles force option to override conflicts', async () => {
+      const spec = createMockSpec({ uuid: validUuid, issueNumber: 789 })
+      const existingIssueWithDifferentUuid = createMockIssue(
+        789,
+        `<!-- spec_id: ${anotherUuid} -->\n\nExisting content`,
+      )
+
+      mockClient.searchIssueByUuid.mockResolvedValue(null)
+      mockClient.getIssue.mockResolvedValue(existingIssueWithDifferentUuid)
+
+      const result = await adapter.push(spec, { force: true })
+
+      expect(mockClient.updateIssue).toHaveBeenCalledWith(
+        789,
+        expect.objectContaining({
+          body: expect.stringContaining(validUuid),
+        }),
+      )
+      expect(result.id).toBe(789)
+    })
+  })
+
+  describe('UUID search functionality', () => {
+    test('finds issues by UUID in body', async () => {
+      const issueWithUuid = createMockIssue(123, `<!-- spec_id: ${validUuid} -->\n\nContent`)
+      mockClient.searchIssueByUuid.mockResolvedValue(issueWithUuid)
+
+      const spec = createMockSpec({ uuid: validUuid })
+      const result = await adapter.push(spec)
+
+      expect(mockClient.searchIssueByUuid).toHaveBeenCalledWith(validUuid)
+      expect(result.id).toBe(123)
+    })
+
+    test('returns null for non-existent UUID', async () => {
+      mockClient.searchIssueByUuid.mockResolvedValue(null)
+
+      const spec = createMockSpec({ uuid: validUuid })
+      await adapter.push(spec)
+
+      expect(mockClient.searchIssueByUuid).toHaveBeenCalledWith(validUuid)
+      expect(mockClient.createIssue).toHaveBeenCalled() // Should create new issue
+    })
+
+    test('handles search API errors gracefully', async () => {
+      mockClient.searchIssueByUuid.mockRejectedValue(new Error('Search API error'))
+
+      const spec = createMockSpec({ uuid: validUuid })
+
+      // Should not throw, should fallback to creation
+      await expect(adapter.push(spec)).resolves.toBeDefined()
+      expect(mockClient.createIssue).toHaveBeenCalled()
+    })
+
+    test('handles multiple partial matches', async () => {
+      // This tests the extraction logic within searchIssueByUuid
+      // The method should find the exact UUID match even if multiple issues contain similar text
+      const exactMatch = createMockIssue(123, `<!-- spec_id: ${validUuid} -->\n\nContent`)
+      mockClient.searchIssueByUuid.mockResolvedValue(exactMatch)
+
+      const spec = createMockSpec({ uuid: validUuid })
+      const result = await adapter.push(spec)
+
+      expect(result.id).toBe(123)
+    })
+  })
+
+  describe('getStatus with UUID priority', () => {
+    test('uses UUID for status checking when available', async () => {
+      const spec = createMockSpec({ uuid: validUuid })
+      const issueWithUuid = createMockIssue(456, `<!-- spec_id: ${validUuid} -->\n\nContent`)
+
+      mockClient.searchIssueByUuid.mockResolvedValue(issueWithUuid)
+
+      const status = await adapter.getStatus(spec)
+
+      expect(mockClient.searchIssueByUuid).toHaveBeenCalledWith(validUuid)
+      expect(status.remoteId).toBe(456)
+    })
+
+    test('falls back to issue_number for status checking', async () => {
+      const spec = createMockSpec({ uuid: validUuid, issueNumber: 789 })
+      const issueByNumber = createMockIssue(789, 'Content without UUID')
+
+      mockClient.searchIssueByUuid.mockResolvedValue(null)
+      mockClient.getIssue.mockResolvedValue(issueByNumber)
+
+      const status = await adapter.getStatus(spec)
+
+      expect(mockClient.searchIssueByUuid).toHaveBeenCalledWith(validUuid)
+      expect(mockClient.getIssue).toHaveBeenCalledWith(789)
+      expect(status.remoteId).toBe(789)
+    })
+
+    test('detects UUID mismatch in status check', async () => {
+      const spec = createMockSpec({ uuid: validUuid, issueNumber: 789 })
+      const issueWithDifferentUuid = createMockIssue(
+        789,
+        `<!-- spec_id: ${anotherUuid} -->\n\nContent`,
+      )
+
+      mockClient.searchIssueByUuid.mockResolvedValue(null)
+      mockClient.getIssue.mockResolvedValue(issueWithDifferentUuid)
+
+      const status = await adapter.getStatus(spec)
+
+      expect(status.status).toBe('conflict')
+      expect(status.conflicts).toContain(
+        expect.stringMatching(/UUID mismatch.*local=.*remote=/),
+      )
+    })
+
+    test('returns draft status when no remote issue found', async () => {
+      const spec = createMockSpec({ uuid: validUuid })
+
+      mockClient.searchIssueByUuid.mockResolvedValue(null)
+      mockClient.getIssue.mockResolvedValue(null)
+
+      const status = await adapter.getStatus(spec)
+
+      expect(status.status).toBe('draft')
+      expect(status.hasChanges).toBe(true)
+    })
+  })
+
+  describe('edge cases', () => {
+    test('handles specs with UUID but no issue_number', async () => {
+      const spec = createMockSpec({ uuid: validUuid }) // No issue_number
+
+      mockClient.searchIssueByUuid.mockResolvedValue(null)
+
+      await adapter.push(spec)
+
+      expect(mockClient.searchIssueByUuid).toHaveBeenCalledWith(validUuid)
+      expect(mockClient.getIssue).not.toHaveBeenCalled()
+      expect(mockClient.createIssue).toHaveBeenCalled()
+    })
+
+    test('handles specs with issue_number but no UUID', async () => {
+      const spec = createMockSpec({ issueNumber: 789 }) // No UUID
+      const existingIssue = createMockIssue(789, 'Existing content')
+
+      mockClient.getIssue.mockResolvedValue(existingIssue)
+
+      const result = await adapter.push(spec)
+
+      expect(mockClient.searchIssueByUuid).not.toHaveBeenCalled()
+      expect(mockClient.getIssue).toHaveBeenCalledWith(789)
+      expect(result.id).toBe(789)
+    })
+
+    test('handles conflicting identifiers', async () => {
+      // UUID points to one issue, issue_number points to another
+      const spec = createMockSpec({ uuid: validUuid, issueNumber: 789 })
+      const issueByUuid = createMockIssue(456, `<!-- spec_id: ${validUuid} -->\n\nContent`)
+
+      mockClient.searchIssueByUuid.mockResolvedValue(issueByUuid)
+
+      const result = await adapter.push(spec)
+
+      // UUID should take priority
+      expect(result.id).toBe(456)
+      expect(mockClient.getIssue).not.toHaveBeenCalled()
+    })
+
+    test('handles malformed UUID in frontmatter', async () => {
+      const spec = createMockSpec({ uuid: 'invalid-uuid-format' })
+
+      // Should not call UUID search with invalid UUID
+      await adapter.push(spec)
+
+      expect(mockClient.searchIssueByUuid).toHaveBeenCalledWith('invalid-uuid-format')
+      expect(mockClient.createIssue).toHaveBeenCalled()
+    })
+
+    test('handles missing spec.md file', async () => {
+      const spec: SpecDocument = {
+        path: '/test/001-test-feature',
+        name: '001-test-feature',
+        files: new Map(), // No spec.md file
+      }
+
+      await expect(adapter.push(spec)).rejects.toThrow(
+        'No spec.md file found in 001-test-feature',
+      )
+    })
+
+    test('handles empty frontmatter', async () => {
+      const specFile: SpecFile = {
+        path: '/test/spec.md',
+        filename: 'spec.md',
+        content: 'Test content',
+        frontmatter: {}, // Empty frontmatter
+        markdown: 'Test content',
+      }
+
+      const spec: SpecDocument = {
+        path: '/test/001-test-feature',
+        name: '001-test-feature',
+        files: new Map([['spec.md', specFile]]),
+      }
+
+      await adapter.push(spec)
+
+      expect(mockClient.searchIssueByUuid).not.toHaveBeenCalled()
+      expect(mockClient.createIssue).toHaveBeenCalled()
+    })
+  })
+
+  describe('batch operations with UUID', () => {
+    test('uses UUID-first matching for batch operations', async () => {
+      const specs = [
+        createMockSpec({ uuid: validUuid }),
+        createMockSpec({ uuid: anotherUuid, issueNumber: 789 }),
+      ]
+
+      const issueByUuid = createMockIssue(456, `<!-- spec_id: ${validUuid} -->\n\nContent`)
+      mockClient.searchIssueByUuid
+        .mockResolvedValueOnce(issueByUuid) // First spec found by UUID
+        .mockResolvedValueOnce(null) // Second spec not found by UUID
+
+      const issueByNumber = createMockIssue(789, 'Content')
+      mockClient.getIssue.mockResolvedValue(issueByNumber)
+
+      const results = await adapter.pushBatch(specs)
+
+      expect(mockClient.searchIssueByUuid).toHaveBeenCalledWith(validUuid)
+      expect(mockClient.searchIssueByUuid).toHaveBeenCalledWith(anotherUuid)
+      expect(mockClient.getIssue).toHaveBeenCalledWith(789)
+      expect(results).toHaveLength(2)
+    })
+
+    test('separates creation and updates correctly with UUID priority', async () => {
+      const specWithExistingIssue = createMockSpec({ uuid: validUuid })
+      const specToCreate = createMockSpec({ uuid: anotherUuid })
+
+      const existingIssue = createMockIssue(456, `<!-- spec_id: ${validUuid} -->\n\nContent`)
+      mockClient.searchIssueByUuid
+        .mockResolvedValueOnce(existingIssue) // First spec has existing issue
+        .mockResolvedValueOnce(null) // Second spec doesn't
+
+      mockClient.createIssue.mockResolvedValue(999)
+
+      const results = await adapter.pushBatch([specWithExistingIssue, specToCreate])
+
+      expect(mockClient.updateIssue).toHaveBeenCalledWith(
+        456,
+        expect.objectContaining({
+          body: expect.stringContaining(validUuid),
+        }),
+      )
+      expect(mockClient.createIssue).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining(anotherUuid),
+        expect.any(Array),
+      )
+      expect(results).toHaveLength(2)
+    })
+  })
+})

--- a/plugins/sync/test/adapters/github.adapter.batch.test.ts
+++ b/plugins/sync/test/adapters/github.adapter.batch.test.ts
@@ -47,6 +47,16 @@ describe('GitHubAdapter - Batch Operations', () => {
         createMockSpec('existing-feature-2', { withIssueNumber: true, issueNumber: 101 }),
       ]
 
+      // Set up mock issues for the update specs
+      updateSpecs.forEach((spec) => {
+        const mainFile = spec.files.get('spec.md')!
+        const issueNumber = mainFile.frontmatter.github?.issue_number
+        if (issueNumber) {
+          const uuid = mainFile.frontmatter.spec_id
+          mockClient.setMockIssueWithUuid(issueNumber, `Feature: ${spec.name}`, uuid, 'Existing content')
+        }
+      })
+
       const allSpecs = [...createSpecs, ...updateSpecs]
 
       const results = await adapter.pushBatch(allSpecs)
@@ -129,10 +139,15 @@ describe('GitHubAdapter - Batch Operations', () => {
     })
 
     test('should skip batch update when no common fields to update', async () => {
-      // Configure adapter without assignees
+      // Configure adapter without assignees or labels
       const simpleAdapter = new GitHubAdapter({
         owner: 'test-owner',
         repo: 'test-repo',
+        labels: {
+          spec: [], // No labels for spec
+          common: [], // No common labels
+        },
+        assignees: [], // No assignees
       })
 
       // @ts-expect-error - accessing private property for testing
@@ -161,7 +176,6 @@ describe('GitHubAdapter - Batch Operations', () => {
 
       expect(results).toHaveLength(1)
       expect(mockClient.batchUpdateIssuesCalls).toHaveLength(0) // No batch update when no common fields
-      expect(mockClient.batchUpdateIssuesCalls[0]?.options.labels).toEqual(['spec']) // Default file type label
       expect(mockClient.updateIssueCalls).toHaveLength(1) // Individual update only
     })
 
@@ -286,6 +300,7 @@ describe('GitHubAdapter - Batch Operations', () => {
 // Helper functions
 function createMockSpec(name: string, options: { withIssueNumber?: boolean, issueNumber?: number } = {}): SpecDocument {
   const frontmatter: any = {
+    spec_id: crypto.randomUUID(),
     issue_type: 'parent',
     sync_status: 'draft',
     auto_sync: true,

--- a/plugins/sync/test/adapters/github.adapter.comprehensive.test.ts
+++ b/plugins/sync/test/adapters/github.adapter.comprehensive.test.ts
@@ -1,4 +1,5 @@
 import type { SpecDocument, SpecFile } from '../../src/types/index.js'
+import { createHash } from 'node:crypto'
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { GitHubAdapter } from '../../src/adapters/github/github.adapter.js'
 import { EnhancedMockGitHubClient } from '../mocks/github-client.mock.js'
@@ -349,12 +350,12 @@ describe('GitHubAdapter - Comprehensive Tests', () => {
 // Helper functions
 function createMockSpec(name: string, options: { withIssueNumber?: boolean, issueNumber?: number } = {}): SpecDocument {
   // Generate a deterministic but valid UUID based on name and issue number
-  const hash = require('crypto').createHash('sha256').update(`${name}-${options.issueNumber || '000'}`).digest('hex')
+  const hash = createHash('sha256').update(`${name}-${options.issueNumber || '000'}`).digest('hex')
   const spec_id = [
     hash.substring(0, 8),
     hash.substring(8, 12),
-    '4' + hash.substring(13, 16), // Version 4
-    ((parseInt(hash.substring(16, 18), 16) & 0x3f) | 0x80).toString(16) + hash.substring(18, 20), // Variant
+    `4${hash.substring(13, 16)}`, // Version 4
+    ((Number.parseInt(hash.substring(16, 18), 16) & 0x3F) | 0x80).toString(16) + hash.substring(18, 20), // Variant
     hash.substring(20, 32),
   ].join('-')
 
@@ -388,12 +389,12 @@ function createMockSpec(name: string, options: { withIssueNumber?: boolean, issu
 
 function createMockSpecWithSubtasks(name: string): SpecDocument {
   // Generate a deterministic but valid UUID
-  const hash = require('crypto').createHash('sha256').update(`${name}-subtasks`).digest('hex')
+  const hash = createHash('sha256').update(`${name}-subtasks`).digest('hex')
   const spec_id = [
     hash.substring(0, 8),
     hash.substring(8, 12),
-    '4' + hash.substring(13, 16),
-    ((parseInt(hash.substring(16, 18), 16) & 0x3f) | 0x80).toString(16) + hash.substring(18, 20),
+    `4${hash.substring(13, 16)}`,
+    ((Number.parseInt(hash.substring(16, 18), 16) & 0x3F) | 0x80).toString(16) + hash.substring(18, 20),
     hash.substring(20, 32),
   ].join('-')
 

--- a/plugins/sync/test/adapters/github.adapter.uuid-matching.test.ts
+++ b/plugins/sync/test/adapters/github.adapter.uuid-matching.test.ts
@@ -320,6 +320,7 @@ function createMockSpec(name: string): SpecDocument {
     path: `specs/${name}/spec.md`,
     filename: 'spec.md',
     frontmatter: {
+      spec_id: crypto.randomUUID(),
       issue_type: 'parent',
       sync_status: 'draft',
       auto_sync: true,

--- a/plugins/sync/test/adapters/github.adapter.uuid-matching.test.ts
+++ b/plugins/sync/test/adapters/github.adapter.uuid-matching.test.ts
@@ -1,0 +1,358 @@
+import type { SpecDocument, SpecFile } from '../../src/types/index.js'
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { GitHubAdapter } from '../../src/adapters/github/github.adapter.js'
+import { embedUuidInIssueBody } from '../../src/adapters/github/uuid-utils.js'
+import { EnhancedMockGitHubClient } from '../mocks/github-client.mock.js'
+
+describe('GitHubAdapter UUID-first matching', () => {
+  let adapter: GitHubAdapter
+  let mockClient: EnhancedMockGitHubClient
+
+  beforeEach(() => {
+    mockClient = new EnhancedMockGitHubClient()
+    adapter = new GitHubAdapter({
+      owner: 'test-owner',
+      repo: 'test-repo',
+    })
+
+    // Replace the client with our mock
+    // @ts-expect-error - accessing private property for testing
+    adapter.client = mockClient
+  })
+
+  describe('UUID-first matching in push()', () => {
+    test('should find existing issue by UUID when spec_id is present', async () => {
+      const uuid = '550e8400-e29b-41d4-a716-446655440000'
+      const existingIssueNumber = 123
+
+      // Create a mock issue with embedded UUID
+      const issueBody = embedUuidInIssueBody('Existing issue body', uuid)
+      mockClient.setMockIssue(existingIssueNumber, {
+        number: existingIssueNumber,
+        title: 'Existing Issue',
+        body: issueBody,
+        state: 'OPEN',
+        labels: ['spec'],
+      })
+
+      const mockSpec = createMockSpecWithUuid('test-feature', uuid)
+
+      const result = await adapter.push(mockSpec)
+
+      // Should have searched by UUID
+      expect(mockClient.searchIssueByUuidCalls).toHaveLength(1)
+      expect(mockClient.searchIssueByUuidCalls[0]).toBe(uuid)
+
+      // Should have updated the existing issue
+      expect(mockClient.updateIssueCalls).toHaveLength(1)
+      expect(mockClient.updateIssueCalls[0]?.number).toBe(existingIssueNumber)
+
+      // Should not have created a new issue
+      expect(mockClient.createIssueCalls).toHaveLength(0)
+
+      // Should return the existing issue
+      expect(result.id).toBe(existingIssueNumber)
+    })
+
+    test('should fallback to issue_number when UUID search finds nothing', async () => {
+      const uuid = '550e8400-e29b-41d4-a716-446655440000'
+      const issueNumber = 456
+
+      // Create a mock issue without UUID (fallback scenario)
+      mockClient.setMockIssue(issueNumber, {
+        number: issueNumber,
+        title: 'Existing Issue',
+        body: 'Regular issue body without UUID',
+        state: 'OPEN',
+        labels: ['spec'],
+      })
+
+      const mockSpec = createMockSpecWithUuidAndIssueNumber('test-feature', uuid, issueNumber)
+
+      const result = await adapter.push(mockSpec)
+
+      // Should have searched by UUID first
+      expect(mockClient.searchIssueByUuidCalls).toHaveLength(1)
+      expect(mockClient.searchIssueByUuidCalls[0]).toBe(uuid)
+
+      // Should have fallen back to getIssue
+      expect(mockClient.getIssueCalls).toHaveLength(1)
+      expect(mockClient.getIssueCalls[0]).toBe(issueNumber)
+
+      // Should have updated the existing issue
+      expect(mockClient.updateIssueCalls).toHaveLength(1)
+      expect(mockClient.updateIssueCalls[0]?.number).toBe(issueNumber)
+
+      // Should not have created a new issue
+      expect(mockClient.createIssueCalls).toHaveLength(0)
+
+      expect(result.id).toBe(issueNumber)
+    })
+
+    test('should detect UUID mismatch and throw error', async () => {
+      const localUuid = '550e8400-e29b-41d4-a716-446655440000'
+      const remoteUuid = '550e8400-e29b-41d4-a716-446655440001'
+      const issueNumber = 789
+
+      // Create a mock issue with different UUID
+      const issueBody = embedUuidInIssueBody('Remote issue body', remoteUuid)
+      mockClient.setMockIssue(issueNumber, {
+        number: issueNumber,
+        title: 'Remote Issue',
+        body: issueBody,
+        state: 'OPEN',
+        labels: ['spec'],
+      })
+
+      const mockSpec = createMockSpecWithUuidAndIssueNumber('test-feature', localUuid, issueNumber)
+
+      await expect(adapter.push(mockSpec)).rejects.toThrow(
+        /UUID mismatch: local spec_id=550e8400-e29b-41d4-a716-446655440000, remote spec_id=550e8400-e29b-41d4-a716-446655440001/,
+      )
+
+      // Should have searched by UUID first (found nothing)
+      expect(mockClient.searchIssueByUuidCalls).toHaveLength(1)
+      expect(mockClient.searchIssueByUuidCalls[0]).toBe(localUuid)
+
+      // Should have fallen back to getIssue
+      expect(mockClient.getIssueCalls).toHaveLength(1)
+      expect(mockClient.getIssueCalls[0]).toBe(issueNumber)
+
+      // Should not have updated or created anything due to error
+      expect(mockClient.updateIssueCalls).toHaveLength(0)
+      expect(mockClient.createIssueCalls).toHaveLength(0)
+    })
+
+    test('should create new issue with embedded UUID when no existing issue found', async () => {
+      const uuid = '550e8400-e29b-41d4-a716-446655440000'
+      const newIssueNumber = 100
+
+      mockClient.setMockCreateIssueResult(newIssueNumber)
+
+      const mockSpec = createMockSpecWithUuid('test-feature', uuid)
+
+      const result = await adapter.push(mockSpec)
+
+      // Should have searched by UUID
+      expect(mockClient.searchIssueByUuidCalls).toHaveLength(1)
+      expect(mockClient.searchIssueByUuidCalls[0]).toBe(uuid)
+
+      // Should have created a new issue
+      expect(mockClient.createIssueCalls).toHaveLength(1)
+
+      // The created issue body should contain the embedded UUID
+      const createCall = mockClient.createIssueCalls[0]
+      expect(createCall?.body).toContain(`<!-- spec_id: ${uuid} -->`)
+
+      // Should not have updated anything
+      expect(mockClient.updateIssueCalls).toHaveLength(0)
+
+      expect(result.id).toBe(newIssueNumber)
+    })
+
+    test('should work without UUID (legacy behavior)', async () => {
+      const issueNumber = 654
+      const newIssueNumber = 101
+
+      // Test case 1: Update existing issue without UUID
+      mockClient.setMockIssue(issueNumber, {
+        number: issueNumber,
+        title: 'Existing Issue',
+        body: 'Regular issue body',
+        state: 'OPEN',
+        labels: ['spec'],
+      })
+
+      const mockSpecWithIssueNumber = createMockSpecWithIssueNumber('test-feature', issueNumber)
+
+      const result1 = await adapter.push(mockSpecWithIssueNumber)
+
+      // Should not have searched by UUID (no UUID provided)
+      expect(mockClient.searchIssueByUuidCalls).toHaveLength(0)
+
+      // Should have used getIssue directly
+      expect(mockClient.getIssueCalls).toHaveLength(1)
+      expect(mockClient.getIssueCalls[0]).toBe(issueNumber)
+
+      expect(result1.id).toBe(issueNumber)
+
+      // Reset for next test
+      mockClient.reset()
+      mockClient.setMockCreateIssueResult(newIssueNumber)
+
+      // Test case 2: Create new issue without UUID
+      const mockSpecWithoutIdentifiers = createMockSpec('new-feature')
+
+      const result2 = await adapter.push(mockSpecWithoutIdentifiers)
+
+      // Should not have searched by UUID
+      expect(mockClient.searchIssueByUuidCalls).toHaveLength(0)
+
+      // Should have created a new issue
+      expect(mockClient.createIssueCalls).toHaveLength(1)
+
+      // The created issue body should NOT contain UUID comments
+      const createCall = mockClient.createIssueCalls[0]
+      expect(createCall?.body).not.toContain('<!-- spec_id:')
+
+      expect(result2.id).toBe(newIssueNumber)
+    })
+
+    test('should force update even when UUID mismatch exists', async () => {
+      const localUuid = '550e8400-e29b-41d4-a716-446655440000'
+      const remoteUuid = '550e8400-e29b-41d4-a716-446655440001'
+      const issueNumber = 789
+
+      // Create a mock issue with different UUID
+      const issueBody = embedUuidInIssueBody('Remote issue body', remoteUuid)
+      mockClient.setMockIssue(issueNumber, {
+        number: issueNumber,
+        title: 'Remote Issue',
+        body: issueBody,
+        state: 'OPEN',
+        labels: ['spec'],
+      })
+
+      const mockSpec = createMockSpecWithUuidAndIssueNumber('test-feature', localUuid, issueNumber)
+
+      // Force push should work despite UUID mismatch - creates new issue when force=true
+      const result = await adapter.push(mockSpec, { force: true })
+
+      // Should still have checked UUIDs
+      expect(mockClient.searchIssueByUuidCalls).toHaveLength(1)
+      expect(mockClient.getIssueCalls).toHaveLength(1)
+
+      // Should have created a new issue (force mode bypasses mismatch validation and existing issue)
+      expect(mockClient.createIssueCalls).toHaveLength(1)
+
+      // Should not have updated the existing issue
+      expect(mockClient.updateIssueCalls).toHaveLength(0)
+
+      expect(result.id).toBe(100) // Default mock creation ID
+    })
+  })
+
+  describe('UUID-first matching in getStatus()', () => {
+    test('should find issue by UUID for status check', async () => {
+      const uuid = '550e8400-e29b-41d4-a716-446655440000'
+      const issueNumber = 123
+
+      // Create a mock issue with embedded UUID
+      const issueBody = embedUuidInIssueBody('Existing issue body', uuid)
+      mockClient.setMockIssue(issueNumber, {
+        number: issueNumber,
+        title: 'Existing Issue',
+        body: issueBody,
+        state: 'OPEN',
+        labels: ['spec'],
+      })
+
+      const mockSpec = createMockSpecWithUuid('test-feature', uuid)
+      // Set sync hash to match the hash calculation and provide last_sync to avoid hasRemoteChanges
+      const mainFile = mockSpec.files.get('spec.md')!
+      const crypto = await import('node:crypto')
+      const contentHash = crypto
+        .createHash('sha256')
+        .update(mainFile.markdown)
+        .digest('hex')
+        .substring(0, 8)
+      mainFile.frontmatter.sync_hash = contentHash
+      mainFile.frontmatter.last_sync = new Date().toISOString()
+
+      const status = await adapter.getStatus(mockSpec)
+
+      // Should have searched by UUID
+      expect(mockClient.searchIssueByUuidCalls).toHaveLength(1)
+      expect(mockClient.searchIssueByUuidCalls[0]).toBe(uuid)
+
+      // Should have found the issue
+      expect(status.status).toBe('synced')
+      expect(status.remoteId).toBe(issueNumber)
+    })
+
+    test('should detect UUID mismatch in status check', async () => {
+      const localUuid = '550e8400-e29b-41d4-a716-446655440000'
+      const remoteUuid = '550e8400-e29b-41d4-a716-446655440001'
+      const issueNumber = 456
+
+      // Create a mock issue with different UUID
+      const issueBody = embedUuidInIssueBody('Remote issue body', remoteUuid)
+      mockClient.setMockIssue(issueNumber, {
+        number: issueNumber,
+        title: 'Remote Issue',
+        body: issueBody,
+        state: 'OPEN',
+        labels: ['spec'],
+      })
+
+      const mockSpec = createMockSpecWithUuidAndIssueNumber('test-feature', localUuid, issueNumber)
+
+      const status = await adapter.getStatus(mockSpec)
+
+      // Should have detected UUID mismatch
+      expect(status.status).toBe('conflict')
+      expect(status.conflicts).toContain(`UUID mismatch: local=${localUuid}, remote=${remoteUuid}`)
+      expect(status.remoteId).toBe(issueNumber)
+    })
+
+    test('should return draft status when no issue found', async () => {
+      const uuid = '550e8400-e29b-41d4-a716-446655440000'
+
+      const mockSpec = createMockSpecWithUuid('test-feature', uuid)
+
+      const status = await adapter.getStatus(mockSpec)
+
+      // Should have searched by UUID
+      expect(mockClient.searchIssueByUuidCalls).toHaveLength(1)
+      expect(mockClient.searchIssueByUuidCalls[0]).toBe(uuid)
+
+      // Should return draft status
+      expect(status.status).toBe('draft')
+      expect(status.hasChanges).toBe(true)
+      expect(status.remoteId).toBeUndefined()
+    })
+  })
+})
+
+// Helper functions
+function createMockSpec(name: string): SpecDocument {
+  const specFile: SpecFile = {
+    path: `specs/${name}/spec.md`,
+    filename: 'spec.md',
+    frontmatter: {
+      issue_type: 'parent',
+      sync_status: 'draft',
+      auto_sync: true,
+    },
+    content: `# ${name}\n\nThis is a test spec.`,
+    markdown: `# ${name}\n\nThis is a test spec.`,
+  }
+
+  return {
+    name,
+    path: `specs/${name}`,
+    files: new Map([['spec.md', specFile]]),
+  }
+}
+
+function createMockSpecWithUuid(name: string, uuid: string): SpecDocument {
+  const spec = createMockSpec(name)
+  const mainFile = spec.files.get('spec.md')!
+  mainFile.frontmatter.spec_id = uuid
+  return spec
+}
+
+function createMockSpecWithIssueNumber(name: string, issueNumber: number): SpecDocument {
+  const spec = createMockSpec(name)
+  const mainFile = spec.files.get('spec.md')!
+  mainFile.frontmatter.github = { issue_number: issueNumber }
+  return spec
+}
+
+function createMockSpecWithUuidAndIssueNumber(name: string, uuid: string, issueNumber: number): SpecDocument {
+  const spec = createMockSpec(name)
+  const mainFile = spec.files.get('spec.md')!
+  mainFile.frontmatter.spec_id = uuid
+  mainFile.frontmatter.github = { issue_number: issueNumber }
+  return spec
+}

--- a/plugins/sync/test/adapters/github/api-uuid.test.ts
+++ b/plugins/sync/test/adapters/github/api-uuid.test.ts
@@ -1,0 +1,447 @@
+import type { GitHubIssue } from '../../../src/types'
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { GitHubClient } from '../../../src/adapters/github/api.js'
+
+// Mock GitHubClient that extends the real one for testing
+class MockGitHubClient extends GitHubClient {
+  public searchIssueCalls: Array<string> = []
+  private mockSearchResults = new Map<string, GitHubIssue[]>()
+  private mockErrors = new Map<string, Error>()
+
+  constructor() {
+    super('test-owner', 'test-repo')
+  }
+
+  // Override to provide direct control over the method
+  override async searchIssueByUuid(uuid: string): Promise<GitHubIssue | null> {
+    // Import the isValidUuid function to use the same validation
+    const { isValidUuid } = await import('../../../src/adapters/github/uuid-utils.js')
+
+    // Validate UUID format before making API call
+    if (!isValidUuid(uuid)) {
+      console.warn(`Invalid UUID format provided: ${uuid}`)
+      return null
+    }
+
+    try {
+      // Use our mock implementation
+      this.searchIssueCalls.push(uuid)
+
+      // Check for mock errors
+      const error = this.mockErrors.get(uuid)
+      if (error) {
+        throw error
+      }
+
+      // Return mock results with UUID extraction logic
+      const results = this.mockSearchResults.get(uuid) || []
+      for (const issue of results) {
+        const { extractUuidFromIssueBody } = await import('../../../src/adapters/github/uuid-utils.js')
+        const extractedUuid = extractUuidFromIssueBody(issue.body)
+        if (extractedUuid === uuid) {
+          return {
+            number: issue.number,
+            title: issue.title,
+            body: issue.body,
+            state: issue.state,
+            labels: issue.labels || [],
+          }
+        }
+      }
+
+      return null
+    }
+    catch (error) {
+      console.warn(`UUID search failed for ${uuid}:`, error)
+      return null
+    }
+  }
+
+  // Mock the executeGhCommand method used by searchIssueByUuid
+  override async executeGhCommand(args: string[]): Promise<string> {
+    if (args[0] === 'search' && args[1] === 'issues') {
+      const queryArg = args.find(arg => arg.includes('spec_id:'))
+      if (queryArg) {
+        // Extract UUID from search query
+        const match = queryArg.match(/spec_id:\s*([a-f0-9-]{36})/i)
+        if (match) {
+          const uuid = match[1]
+          this.searchIssueCalls.push(uuid)
+
+          // Check for mock errors
+          const error = this.mockErrors.get(uuid)
+          if (error) {
+            throw error
+          }
+
+          // Return mock results with proper mapping for labels
+          const results = this.mockSearchResults.get(uuid) || []
+          const processedResults = results.map(result => ({
+            ...result,
+            labels: result.labels?.map(name => ({ name })) || [],
+          }))
+          return JSON.stringify(processedResults)
+        }
+      }
+    }
+
+    // Fallback to prevent errors in other tests
+    return JSON.stringify([])
+  }
+
+  // Test utilities
+  setMockSearchResult(uuid: string, results: GitHubIssue[]): void {
+    this.mockSearchResults.set(uuid, results)
+  }
+
+  setMockSearchError(uuid: string, error: Error): void {
+    this.mockErrors.set(uuid, error)
+  }
+
+  reset(): void {
+    this.searchIssueCalls = []
+    this.mockSearchResults.clear()
+    this.mockErrors.clear()
+  }
+}
+
+describe('GitHubClient UUID Search', () => {
+  let client: MockGitHubClient
+
+  const validUuid = '550e8400-e29b-41d4-a716-446655440000'
+  const invalidUuid = 'invalid-uuid-format'
+  const notFoundUuid = 'f47ac10b-58cc-4372-a567-0e02b2c3d479'
+
+  beforeEach(() => {
+    client = new MockGitHubClient()
+  })
+
+  describe('searchIssueByUuid', () => {
+    test('returns issue when UUID is found', async () => {
+      const mockIssue: GitHubIssue = {
+        number: 123,
+        title: 'Test Issue',
+        body: `<!-- spec_id: ${validUuid} -->\n\nIssue content`,
+        state: 'OPEN',
+        labels: ['feature', 'spec'],
+      }
+
+      client.setMockSearchResult(validUuid, [mockIssue])
+
+      const result = await client.searchIssueByUuid(validUuid)
+
+      expect(result).toEqual({
+        number: 123,
+        title: 'Test Issue',
+        body: `<!-- spec_id: ${validUuid} -->\n\nIssue content`,
+        state: 'OPEN',
+        labels: ['feature', 'spec'],
+      })
+      expect(client.searchIssueCalls).toContain(validUuid)
+    })
+
+    test('returns null when UUID is not found', async () => {
+      client.setMockSearchResult(notFoundUuid, [])
+
+      const result = await client.searchIssueByUuid(notFoundUuid)
+
+      expect(result).toBeNull()
+      expect(client.searchIssueCalls).toContain(notFoundUuid)
+    })
+
+    test('returns null for invalid UUID format', async () => {
+      const originalWarn = console.warn
+      const warnCalls: any[][] = []
+      console.warn = (...args: any[]) => {
+        warnCalls.push(args)
+      }
+
+      const result = await client.searchIssueByUuid(invalidUuid)
+
+      expect(result).toBeNull()
+      expect(warnCalls.length).toBe(1)
+      expect(warnCalls[0]).toEqual([`Invalid UUID format provided: ${invalidUuid}`])
+      expect(client.searchIssueCalls).not.toContain(invalidUuid)
+
+      console.warn = originalWarn
+    })
+
+    test('finds exact UUID match from multiple results', async () => {
+      const targetUuid = validUuid
+      const otherUuid = 'f47ac10b-58cc-4372-a567-0e02b2c3d479'
+
+      const matchingIssue: GitHubIssue = {
+        number: 123,
+        title: 'Matching Issue',
+        body: `<!-- spec_id: ${targetUuid} -->\n\nCorrect issue`,
+        state: 'OPEN',
+        labels: [],
+      }
+
+      const nonMatchingIssue: GitHubIssue = {
+        number: 124,
+        title: 'Non-matching Issue',
+        body: `<!-- spec_id: ${otherUuid} -->\n\nWrong issue`,
+        state: 'OPEN',
+        labels: [],
+      }
+
+      // Mock search returns both issues (simulating partial text match)
+      client.setMockSearchResult(targetUuid, [nonMatchingIssue, matchingIssue])
+
+      const result = await client.searchIssueByUuid(targetUuid)
+
+      expect(result).toEqual(matchingIssue)
+      expect(result?.number).toBe(123)
+    })
+
+    test('returns null when no exact UUID match in results', async () => {
+      const searchUuid = validUuid
+      const differentUuid = 'f47ac10b-58cc-4372-a567-0e02b2c3d479'
+
+      const issueWithDifferentUuid: GitHubIssue = {
+        number: 123,
+        title: 'Different UUID Issue',
+        body: `<!-- spec_id: ${differentUuid} -->\n\nWrong UUID`,
+        state: 'OPEN',
+        labels: [],
+      }
+
+      // Search finds issues but none have the exact UUID
+      client.setMockSearchResult(searchUuid, [issueWithDifferentUuid])
+
+      const result = await client.searchIssueByUuid(searchUuid)
+
+      expect(result).toBeNull()
+    })
+
+    test('handles search API errors gracefully', async () => {
+      const originalWarn = console.warn
+      const warnCalls: any[][] = []
+      console.warn = (...args: any[]) => {
+        warnCalls.push(args)
+      }
+      const searchError = new Error('GitHub API rate limit exceeded')
+
+      client.setMockSearchError(validUuid, searchError)
+
+      const result = await client.searchIssueByUuid(validUuid)
+
+      expect(result).toBeNull()
+      expect(warnCalls.length).toBe(1)
+      expect(warnCalls[0]).toEqual([`UUID search failed for ${validUuid}:`, searchError])
+
+      console.warn = originalWarn
+    })
+
+    test('handles issues without UUID metadata', async () => {
+      const issueWithoutUuid: GitHubIssue = {
+        number: 123,
+        title: 'Issue Without UUID',
+        body: 'Regular issue content without UUID',
+        state: 'OPEN',
+        labels: [],
+      }
+
+      client.setMockSearchResult(validUuid, [issueWithoutUuid])
+
+      const result = await client.searchIssueByUuid(validUuid)
+
+      expect(result).toBeNull()
+    })
+
+    test('handles issues with malformed UUID comments', async () => {
+      const issueWithMalformedUuid: GitHubIssue = {
+        number: 123,
+        title: 'Issue With Malformed UUID',
+        body: '<!-- spec_id: malformed-uuid -->\n\nContent',
+        state: 'OPEN',
+        labels: [],
+      }
+
+      client.setMockSearchResult(validUuid, [issueWithMalformedUuid])
+
+      const result = await client.searchIssueByUuid(validUuid)
+
+      expect(result).toBeNull()
+    })
+
+    test('returns issue with empty labels array when no labels present', async () => {
+      const issueWithoutLabels: GitHubIssue = {
+        number: 123,
+        title: 'Issue Without Labels',
+        body: `<!-- spec_id: ${validUuid} -->\n\nContent`,
+        state: 'OPEN',
+        labels: [], // Explicit empty array
+      }
+
+      client.setMockSearchResult(validUuid, [issueWithoutLabels])
+
+      const result = await client.searchIssueByUuid(validUuid)
+
+      expect(result).not.toBeNull()
+      expect(result!.labels).toEqual([])
+    })
+
+    test('validates UUID before making API call', async () => {
+      const originalWarn = console.warn
+      const warnCalls: any[][] = []
+      console.warn = (...args: any[]) => {
+        warnCalls.push(args)
+      }
+
+      // Test various invalid UUID formats
+      const invalidUuids = [
+        '',
+        'not-a-uuid',
+        '123',
+        '550e8400-e29b-41d4-a716', // too short
+        '550e8400-e29b-41d4-a716-446655440000-extra', // too long
+        '550e8400-e29b-31d4-a716-446655440000', // wrong version (3 instead of 4)
+        'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx', // invalid characters
+      ]
+
+      for (const uuid of invalidUuids) {
+        const result = await client.searchIssueByUuid(uuid)
+        expect(result).toBeNull()
+      }
+
+      // Should have one warning for each invalid UUID
+      expect(warnCalls.length).toBe(invalidUuids.length)
+      for (let i = 0; i < invalidUuids.length; i++) {
+        expect(warnCalls[i]).toEqual([`Invalid UUID format provided: ${invalidUuids[i]}`])
+      }
+
+      // No API calls should have been made
+      expect(client.searchIssueCalls).toHaveLength(0)
+
+      console.warn = originalWarn
+    })
+
+    test('constructs correct search query', async () => {
+      const uuid = validUuid
+      client.setMockSearchResult(uuid, [])
+
+      await client.searchIssueByUuid(uuid)
+
+      // Verify the UUID was extracted correctly from the search query
+      expect(client.searchIssueCalls).toContain(uuid)
+    })
+  })
+
+  describe('UUID validation edge cases', () => {
+    test('accepts valid UUID v4 formats', async () => {
+      const validV4Uuids = [
+        '550e8400-e29b-41d4-a716-446655440000',
+        'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+        '123e4567-e89b-42d3-a456-426614174000',
+        'AAAAAAAA-BBBB-4CCC-9DDD-EEEEEEEEEEEE', // uppercase
+      ]
+
+      for (const uuid of validV4Uuids) {
+        client.setMockSearchResult(uuid, [])
+        const result = await client.searchIssueByUuid(uuid)
+        // Should not error out, even if no results
+        expect(result).toBeNull()
+      }
+
+      expect(client.searchIssueCalls).toHaveLength(validV4Uuids.length)
+    })
+
+    test('rejects non-v4 UUID versions', async () => {
+      const originalWarn = console.warn
+      const warnCalls: any[][] = []
+      console.warn = (...args: any[]) => {
+        warnCalls.push(args)
+      }
+
+      const nonV4Uuids = [
+        '550e8400-e29b-11d4-a716-446655440000', // version 1
+        '550e8400-e29b-21d4-a716-446655440000', // version 2
+        '550e8400-e29b-31d4-a716-446655440000', // version 3
+        '550e8400-e29b-51d4-a716-446655440000', // version 5
+      ]
+
+      for (const uuid of nonV4Uuids) {
+        const result = await client.searchIssueByUuid(uuid)
+        expect(result).toBeNull()
+      }
+
+      expect(warnCalls.length).toBe(nonV4Uuids.length)
+      for (let i = 0; i < nonV4Uuids.length; i++) {
+        expect(warnCalls[i]).toEqual([`Invalid UUID format provided: ${nonV4Uuids[i]}`])
+      }
+
+      expect(client.searchIssueCalls).toHaveLength(0)
+
+      console.warn = originalWarn
+    })
+  })
+
+  describe('performance and reliability', () => {
+    test('handles large search result sets efficiently', async () => {
+      // Create a large number of mock issues
+      const manyIssues: GitHubIssue[] = Array.from({ length: 100 }, (_, i) => ({
+        number: i + 1,
+        title: `Issue ${i + 1}`,
+        body: `Content for issue ${i + 1}`,
+        state: 'OPEN' as const,
+        labels: [],
+      }))
+
+      // Add the target issue at the end
+      const targetIssue: GitHubIssue = {
+        number: 101,
+        title: 'Target Issue',
+        body: `<!-- spec_id: ${validUuid} -->\n\nTarget content`,
+        state: 'OPEN',
+        labels: ['target'],
+      }
+      manyIssues.push(targetIssue)
+
+      client.setMockSearchResult(validUuid, manyIssues)
+
+      const startTime = Date.now()
+      const result = await client.searchIssueByUuid(validUuid)
+      const endTime = Date.now()
+
+      expect(result).toEqual(targetIssue)
+      expect(endTime - startTime).toBeLessThan(100) // Should be fast
+    })
+
+    test('handles concurrent search requests', async () => {
+      const uuid1 = validUuid
+      const uuid2 = 'f47ac10b-58cc-4372-a567-0e02b2c3d479'
+
+      const issue1: GitHubIssue = {
+        number: 1,
+        title: 'Issue 1',
+        body: `<!-- spec_id: ${uuid1} -->\n\nContent 1`,
+        state: 'OPEN',
+        labels: [],
+      }
+
+      const issue2: GitHubIssue = {
+        number: 2,
+        title: 'Issue 2',
+        body: `<!-- spec_id: ${uuid2} -->\n\nContent 2`,
+        state: 'OPEN',
+        labels: [],
+      }
+
+      client.setMockSearchResult(uuid1, [issue1])
+      client.setMockSearchResult(uuid2, [issue2])
+
+      // Make concurrent requests
+      const [result1, result2] = await Promise.all([
+        client.searchIssueByUuid(uuid1),
+        client.searchIssueByUuid(uuid2),
+      ])
+
+      expect(result1).toEqual(issue1)
+      expect(result2).toEqual(issue2)
+      expect(client.searchIssueCalls).toContain(uuid1)
+      expect(client.searchIssueCalls).toContain(uuid2)
+    })
+  })
+})

--- a/plugins/sync/test/adapters/github/uuid-utils.test.ts
+++ b/plugins/sync/test/adapters/github/uuid-utils.test.ts
@@ -1,0 +1,338 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  embedUuidInIssueBody,
+  extractUuidFromIssueBody,
+  hasUuidMetadata,
+  isValidUuid,
+  removeUuidFromIssueBody,
+} from '../../../src/adapters/github/uuid-utils'
+
+describe('UUID Utils', () => {
+  const _validUuid = '550e8400-e29b-41d4-a716-446655440000'
+  const validUuidV4 = '123e4567-e89b-42d3-a456-426614174000'
+  const invalidUuid = 'not-a-uuid'
+  const malformedUuid = '550e8400-e29b-41d4-a716-44665544000'
+  const wrongVersionUuid = '550e8400-e29b-31d4-a716-446655440000' // version 3, not 4
+
+  describe('isValidUuid', () => {
+    test('validates correct UUID v4 format', () => {
+      expect(isValidUuid(validUuidV4)).toBe(true)
+      expect(isValidUuid('f47ac10b-58cc-4372-a567-0e02b2c3d479')).toBe(true)
+    })
+
+    test('accepts UUID with uppercase letters', () => {
+      expect(isValidUuid('550E8400-E29B-41D4-A716-446655440000')).toBe(true)
+    })
+
+    test('rejects invalid formats', () => {
+      expect(isValidUuid(invalidUuid)).toBe(false)
+      expect(isValidUuid(malformedUuid)).toBe(false)
+      expect(isValidUuid('123-456-789')).toBe(false)
+      expect(isValidUuid('')).toBe(false)
+    })
+
+    test('validates strict UUID v4 format', () => {
+      // Should accept valid v4 UUID (4 in version position)
+      expect(isValidUuid('123e4567-e89b-42d3-a456-426614174000')).toBe(true)
+
+      // Should reject other versions due to strict v4 validation
+      expect(isValidUuid(wrongVersionUuid)).toBe(false)
+    })
+
+    test('handles edge cases', () => {
+      expect(isValidUuid('')).toBe(false)
+      // TypeScript will prevent null/undefined at compile time, but testing runtime behavior
+      expect(isValidUuid(null as any)).toBe(false)
+      expect(isValidUuid(undefined as any)).toBe(false)
+      expect(isValidUuid(123 as any)).toBe(false)
+      expect(isValidUuid({} as any)).toBe(false)
+    })
+  })
+
+  describe('embedUuidInIssueBody', () => {
+    test('embeds UUID at beginning of body', () => {
+      const body = 'This is the issue description'
+      const result = embedUuidInIssueBody(body, validUuidV4)
+
+      expect(result).toStartWith(`<!-- spec_id: ${validUuidV4} -->`)
+      expect(result).toContain(body)
+      expect(result).toMatch(/^<!-- spec_id: .+ -->\n\nThis is the issue description$/)
+    })
+
+    test('replaces existing UUID comment', () => {
+      const existingUuid = 'f47ac10b-58cc-4372-a567-0e02b2c3d479'
+      const bodyWithUuid = `<!-- spec_id: ${existingUuid} -->\n\nOriginal content`
+
+      const result = embedUuidInIssueBody(bodyWithUuid, validUuidV4)
+
+      expect(result).toContain(validUuidV4)
+      expect(result).not.toContain(existingUuid)
+      expect(result).toContain('Original content')
+
+      // Should have only one UUID comment
+      const uuidMatches = result.match(/<!-- spec_id:/g)
+      expect(uuidMatches).toHaveLength(1)
+    })
+
+    test('handles empty body', () => {
+      const result = embedUuidInIssueBody('', validUuidV4)
+
+      expect(result).toBe(`<!-- spec_id: ${validUuidV4} -->\n\n`)
+    })
+
+    test('handles whitespace-only body', () => {
+      const result = embedUuidInIssueBody('   \n\t  ', validUuidV4)
+
+      expect(result).toBe(`<!-- spec_id: ${validUuidV4} -->\n\n`)
+    })
+
+    test('preserves body formatting', () => {
+      const bodyWithFormatting = `# Title
+
+## Section
+- Item 1
+- Item 2
+
+**Bold text**`
+
+      const result = embedUuidInIssueBody(bodyWithFormatting, validUuidV4)
+
+      expect(result).toStartWith(`<!-- spec_id: ${validUuidV4} -->`)
+      expect(result).toContain('# Title')
+      expect(result).toContain('**Bold text**')
+    })
+
+    test('throws on invalid UUID', () => {
+      expect(() => {
+        embedUuidInIssueBody('body content', invalidUuid)
+      }).toThrow('Invalid UUID format')
+
+      expect(() => {
+        embedUuidInIssueBody('body content', malformedUuid)
+      }).toThrow('Invalid UUID format')
+
+      expect(() => {
+        embedUuidInIssueBody('body content', '')
+      }).toThrow('Invalid UUID format')
+    })
+  })
+
+  describe('extractUuidFromIssueBody', () => {
+    test('extracts UUID from comment', () => {
+      const body = `<!-- spec_id: ${validUuidV4} -->\n\nIssue description`
+      const result = extractUuidFromIssueBody(body)
+
+      expect(result).toBe(validUuidV4)
+    })
+
+    test('extracts UUID with different spacing', () => {
+      const bodyVariations = [
+        `<!--spec_id:${validUuidV4}-->\n\nContent`,
+        `<!-- spec_id:${validUuidV4} -->\n\nContent`,
+        `<!--  spec_id: ${validUuidV4}  -->\n\nContent`,
+      ]
+
+      bodyVariations.forEach((body) => {
+        const result = extractUuidFromIssueBody(body)
+        expect(result).toBe(validUuidV4)
+      })
+    })
+
+    test('returns null when no UUID found', () => {
+      const bodiesWithoutUuid = [
+        'Regular issue description',
+        '<!-- some other comment -->',
+        '<!-- spec_id: invalid-uuid -->',
+        '',
+        'No UUID here at all',
+      ]
+
+      bodiesWithoutUuid.forEach((body) => {
+        const result = extractUuidFromIssueBody(body)
+        expect(result).toBeNull()
+      })
+    })
+
+    test('handles malformed comments', () => {
+      const malformedComments = [
+        '<!-- spec_id: -->',
+        '<!-- spec_id: not-a-uuid -->',
+        `<!-- spec_id \${validUuidV4} -->`, // missing colon
+        `<!-- spec_id: \${malformedUuid} -->`, // invalid UUID format
+      ]
+
+      malformedComments.forEach((body) => {
+        const result = extractUuidFromIssueBody(body)
+        expect(result).toBeNull()
+      })
+    })
+
+    test('extracts first UUID when multiple present', () => {
+      const firstUuid = validUuidV4
+      const secondUuid = 'f47ac10b-58cc-4372-a567-0e02b2c3d479'
+      const body = `<!-- spec_id: ${firstUuid} -->
+<!-- spec_id: ${secondUuid} -->
+Content`
+
+      const result = extractUuidFromIssueBody(body)
+      expect(result).toBe(firstUuid)
+    })
+
+    test('handles case insensitive UUID format', () => {
+      const uppercaseUuid = validUuidV4.toUpperCase()
+      const body = `<!-- spec_id: ${uppercaseUuid} -->\n\nContent`
+
+      const result = extractUuidFromIssueBody(body)
+      expect(result).toBe(uppercaseUuid)
+    })
+
+    test('handles UUID in middle of body', () => {
+      const body = `Some content here
+
+<!-- spec_id: ${validUuidV4} -->
+
+More content below`
+
+      const result = extractUuidFromIssueBody(body)
+      expect(result).toBe(validUuidV4)
+    })
+  })
+
+  describe('hasUuidMetadata', () => {
+    test('detects UUID presence', () => {
+      const bodyWithUuid = `<!-- spec_id: ${validUuidV4} -->\n\nContent`
+      expect(hasUuidMetadata(bodyWithUuid)).toBe(true)
+    })
+
+    test('handles bodies without UUID', () => {
+      const bodiesWithoutUuid = [
+        'Regular content',
+        '<!-- some other comment -->',
+        '',
+        '<!-- spec_id: invalid -->',
+        'No metadata here',
+      ]
+
+      bodiesWithoutUuid.forEach((body) => {
+        expect(hasUuidMetadata(body)).toBe(false)
+      })
+    })
+
+    test('detects UUID regardless of position', () => {
+      const bodies = [
+        `<!-- spec_id: ${validUuidV4} -->\n\nContent`,
+        `Content\n<!-- spec_id: ${validUuidV4} -->\nMore content`,
+        `Some text\n\n<!-- spec_id: ${validUuidV4} -->`,
+      ]
+
+      bodies.forEach((body) => {
+        expect(hasUuidMetadata(body)).toBe(true)
+      })
+    })
+  })
+
+  describe('removeUuidFromIssueBody', () => {
+    test('removes UUID comment and preserves content', () => {
+      const content = 'Issue description with details'
+      const bodyWithUuid = `<!-- spec_id: ${validUuidV4} -->\n\n${content}`
+
+      const result = removeUuidFromIssueBody(bodyWithUuid)
+      expect(result).toBe(content)
+      expect(result).not.toContain('spec_id')
+    })
+
+    test('handles body without UUID', () => {
+      const originalBody = 'Regular issue content'
+      const result = removeUuidFromIssueBody(originalBody)
+
+      expect(result).toBe(originalBody)
+    })
+
+    test('removes UUID from middle of content', () => {
+      const body = `First paragraph
+
+<!-- spec_id: ${validUuidV4} -->
+
+Second paragraph`
+
+      const result = removeUuidFromIssueBody(body)
+      expect(result).toBe('First paragraph\n\nSecond paragraph')
+      expect(result).not.toContain('spec_id')
+    })
+
+    test('handles multiple UUID comments', () => {
+      const body = `<!-- spec_id: ${validUuidV4} -->
+Content here
+<!-- spec_id: f47ac10b-58cc-4372-a567-0e02b2c3d479 -->
+More content`
+
+      const result = removeUuidFromIssueBody(body)
+      expect(result).toContain('Content here')
+      expect(result).toContain('More content')
+      expect(result).not.toContain('spec_id')
+    })
+
+    test('trims whitespace after removal', () => {
+      const bodyWithExtraWhitespace = `   <!-- spec_id: ${validUuidV4} -->   \n\n   Content   \n\n   `
+
+      const result = removeUuidFromIssueBody(bodyWithExtraWhitespace)
+      expect(result).toBe('Content')
+    })
+
+    test('handles empty body after UUID removal', () => {
+      const onlyUuidBody = `<!-- spec_id: ${validUuidV4} -->`
+
+      const result = removeUuidFromIssueBody(onlyUuidBody)
+      expect(result).toBe('')
+    })
+  })
+
+  describe('edge cases and error conditions', () => {
+    test('handles very long UUIDs in comments', () => {
+      const tooLongUuid = 'f47ac10b-58cc-4372-a567-0e02b2c3d479-extra'
+      const body = `<!-- spec_id: ${tooLongUuid} -->\n\nContent`
+
+      expect(extractUuidFromIssueBody(body)).toBeNull()
+      expect(hasUuidMetadata(body)).toBe(false)
+    })
+
+    test('handles special characters in body around UUID', () => {
+      const body = `🎉 Welcome!
+<!-- spec_id: ${validUuidV4} -->
+**Bold** _italic_ \`code\``
+
+      const result = extractUuidFromIssueBody(body)
+      expect(result).toBe(validUuidV4)
+
+      const cleaned = removeUuidFromIssueBody(body)
+      expect(cleaned).toContain('🎉 Welcome!')
+      expect(cleaned).toContain('**Bold**')
+    })
+
+    test('performance with large body content', () => {
+      const largeContent = 'A'.repeat(10000)
+      const bodyWithUuid = `<!-- spec_id: ${validUuidV4} -->\n\n${largeContent}`
+
+      const startTime = Date.now()
+      const extracted = extractUuidFromIssueBody(bodyWithUuid)
+      const endTime = Date.now()
+
+      expect(extracted).toBe(validUuidV4)
+      expect(endTime - startTime).toBeLessThan(100) // Should be fast
+    })
+
+    test('handles nested comment-like strings', () => {
+      const body = `<!-- spec_id: ${validUuidV4} -->
+
+Content with <!-- fake comment --> inside
+
+And more content`
+
+      const result = extractUuidFromIssueBody(body)
+      expect(result).toBe(validUuidV4)
+
+      const cleaned = removeUuidFromIssueBody(body)
+      expect(cleaned).toContain('<!-- fake comment -->')
+    })
+  })
+})

--- a/plugins/sync/test/core/frontmatter-uuid.test.ts
+++ b/plugins/sync/test/core/frontmatter-uuid.test.ts
@@ -1,0 +1,277 @@
+import type { SpecFileFrontmatter } from '../../src/types'
+import { describe, expect, test } from 'bun:test'
+import {
+  ensureValidSpecId,
+  safeValidateSpecId,
+  validateSpecId,
+} from '../../src/core/frontmatter'
+
+describe('Frontmatter UUID Validation', () => {
+  const _validUuid = '550e8400-e29b-41d4-a716-446655440000'
+  const validUuidV4 = '123e4567-e89b-42d3-a456-426614174000'
+  const invalidUuid = 'not-a-uuid'
+  const malformedUuid = '550e8400-e29b-41d4-a716-44665544000' // missing digit
+  const wrongVersionUuid = '550e8400-e29b-31d4-a716-446655440000' // version 3
+
+  describe('validateSpecId', () => {
+    test('validates correct UUID v4 format', () => {
+      expect(validateSpecId(validUuidV4)).toBe(validUuidV4)
+      expect(validateSpecId('f47ac10b-58cc-4372-a567-0e02b2c3d479')).toBe('f47ac10b-58cc-4372-a567-0e02b2c3d479')
+    })
+
+    test('accepts UUID with uppercase letters', () => {
+      const uppercaseUuid = 'F47AC10B-58CC-4372-A567-0E02B2C3D479'
+      expect(validateSpecId(uppercaseUuid)).toBe(uppercaseUuid)
+    })
+
+    test('throws error for invalid UUID formats', () => {
+      expect(() => validateSpecId(invalidUuid)).toThrow('Invalid spec_id format: not-a-uuid')
+      expect(() => validateSpecId(malformedUuid)).toThrow('Invalid spec_id format')
+      expect(() => validateSpecId('')).toThrow('Invalid spec_id format')
+    })
+
+    test('throws error for non-v4 UUIDs', () => {
+      expect(() => validateSpecId(wrongVersionUuid)).toThrow('Invalid spec_id format')
+    })
+
+    test('throws error for non-string input', () => {
+      expect(() => validateSpecId(123)).toThrow('spec_id must be a string')
+      expect(() => validateSpecId(null)).toThrow('spec_id must be a string')
+      expect(() => validateSpecId(undefined)).toThrow('spec_id must be a string')
+      expect(() => validateSpecId({})).toThrow('spec_id must be a string')
+      expect(() => validateSpecId([])).toThrow('spec_id must be a string')
+    })
+
+    test('handles edge cases', () => {
+      expect(() => validateSpecId('  ')).toThrow('Invalid spec_id format')
+      expect(() => validateSpecId('\n')).toThrow('Invalid spec_id format')
+      expect(() => validateSpecId('\t')).toThrow('Invalid spec_id format')
+    })
+  })
+
+  describe('safeValidateSpecId', () => {
+    test('returns valid UUID for correct format', () => {
+      expect(safeValidateSpecId(validUuidV4)).toBe(validUuidV4)
+      expect(safeValidateSpecId('f47ac10b-58cc-4372-a567-0e02b2c3d479')).toBe('f47ac10b-58cc-4372-a567-0e02b2c3d479')
+    })
+
+    test('returns null for invalid formats without throwing', () => {
+      expect(safeValidateSpecId(invalidUuid)).toBeNull()
+      expect(safeValidateSpecId(malformedUuid)).toBeNull()
+      expect(safeValidateSpecId('')).toBeNull()
+      expect(safeValidateSpecId(wrongVersionUuid)).toBeNull()
+    })
+
+    test('returns null for non-string input without throwing', () => {
+      expect(safeValidateSpecId(123)).toBeNull()
+      expect(safeValidateSpecId(null)).toBeNull()
+      expect(safeValidateSpecId(undefined)).toBeNull()
+      expect(safeValidateSpecId({})).toBeNull()
+      expect(safeValidateSpecId([])).toBeNull()
+    })
+
+    test('handles edge cases gracefully', () => {
+      expect(safeValidateSpecId('  ')).toBeNull()
+      expect(safeValidateSpecId('\n')).toBeNull()
+      expect(safeValidateSpecId('\t')).toBeNull()
+    })
+
+    test('accepts uppercase UUIDs', () => {
+      const uppercaseUuid = 'F47AC10B-58CC-4372-A567-0E02B2C3D479'
+      expect(safeValidateSpecId(uppercaseUuid)).toBe(uppercaseUuid)
+    })
+  })
+
+  describe('ensureValidSpecId', () => {
+    test('preserves existing valid UUID', () => {
+      const frontmatter: Partial<SpecFileFrontmatter> = {
+        spec_id: validUuidV4,
+        sync_status: 'draft',
+      }
+
+      const result = ensureValidSpecId(frontmatter)
+
+      expect(result.spec_id).toBe(validUuidV4)
+      expect(result.sync_status).toBe('draft')
+    })
+
+    test('generates new UUID for missing spec_id', () => {
+      const frontmatter: Partial<SpecFileFrontmatter> = {
+        sync_status: 'draft',
+        auto_sync: true,
+      }
+
+      const result = ensureValidSpecId(frontmatter)
+
+      expect(result.spec_id).toBeDefined()
+      expect(typeof result.spec_id).toBe('string')
+      expect(result.spec_id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
+      expect(result.sync_status).toBe('draft')
+      expect(result.auto_sync).toBe(true)
+    })
+
+    test('generates new UUID for invalid spec_id', () => {
+      const frontmatter: Partial<SpecFileFrontmatter> = {
+        spec_id: invalidUuid as any, // Type cast to bypass TypeScript checking
+        sync_status: 'draft',
+      }
+
+      const result = ensureValidSpecId(frontmatter)
+
+      expect(result.spec_id).toBeDefined()
+      expect(result.spec_id).not.toBe(invalidUuid)
+      expect(result.spec_id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
+      expect(result.sync_status).toBe('draft')
+    })
+
+    test('generates new UUID for malformed spec_id', () => {
+      const frontmatter: Partial<SpecFileFrontmatter> = {
+        spec_id: malformedUuid as any,
+        sync_status: 'draft',
+      }
+
+      const result = ensureValidSpecId(frontmatter)
+
+      expect(result.spec_id).toBeDefined()
+      expect(result.spec_id).not.toBe(malformedUuid)
+      expect(result.spec_id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
+    })
+
+    test('generates new UUID for empty spec_id', () => {
+      const frontmatter: Partial<SpecFileFrontmatter> = {
+        spec_id: '' as any,
+        sync_status: 'draft',
+      }
+
+      const result = ensureValidSpecId(frontmatter)
+
+      expect(result.spec_id).toBeDefined()
+      expect(result.spec_id).not.toBe('')
+      expect(result.spec_id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
+    })
+
+    test('handles completely empty frontmatter', () => {
+      const frontmatter: Partial<SpecFileFrontmatter> = {}
+
+      const result = ensureValidSpecId(frontmatter)
+
+      expect(result.spec_id).toBeDefined()
+      expect(typeof result.spec_id).toBe('string')
+      expect(result.spec_id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
+    })
+
+    test('preserves all other frontmatter properties', () => {
+      const frontmatter: Partial<SpecFileFrontmatter> = {
+        spec_id: validUuidV4,
+        sync_status: 'synced',
+        auto_sync: false,
+        issue_type: 'parent',
+        last_sync: '2023-01-01T00:00:00Z',
+        sync_hash: 'abc123def456',
+        github: {
+          issue_number: 123,
+          parent_issue: 456,
+          labels: ['feature', 'spec'],
+        },
+        jira: {
+          issue_key: 'PROJ-123',
+          epic_key: 'PROJ-100',
+        },
+      }
+
+      const result = ensureValidSpecId(frontmatter)
+
+      expect(result.spec_id).toBe(validUuidV4)
+      expect(result.sync_status).toBe('synced')
+      expect(result.auto_sync).toBe(false)
+      expect(result.issue_type).toBe('parent')
+      expect(result.last_sync).toBe('2023-01-01T00:00:00Z')
+      expect(result.sync_hash).toBe('abc123def456')
+      expect(result.github).toEqual({
+        issue_number: 123,
+        parent_issue: 456,
+        labels: ['feature', 'spec'],
+      })
+      expect(result.jira).toEqual({
+        issue_key: 'PROJ-123',
+        epic_key: 'PROJ-100',
+      })
+    })
+
+    test('generates unique UUIDs on multiple calls', () => {
+      const frontmatter1: Partial<SpecFileFrontmatter> = { sync_status: 'draft' }
+      const frontmatter2: Partial<SpecFileFrontmatter> = { sync_status: 'draft' }
+
+      const result1 = ensureValidSpecId(frontmatter1)
+      const result2 = ensureValidSpecId(frontmatter2)
+
+      expect(result1.spec_id).toBeDefined()
+      expect(result2.spec_id).toBeDefined()
+      expect(result1.spec_id).not.toBe(result2.spec_id)
+
+      // Both should be valid UUIDs
+      expect(result1.spec_id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
+      expect(result2.spec_id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
+    })
+
+    test('handles null and undefined spec_id', () => {
+      const frontmatterWithNull: Partial<SpecFileFrontmatter> = {
+        spec_id: null as any,
+        sync_status: 'draft',
+      }
+
+      const frontmatterWithUndefined: Partial<SpecFileFrontmatter> = {
+        spec_id: undefined,
+        sync_status: 'draft',
+      }
+
+      const result1 = ensureValidSpecId(frontmatterWithNull)
+      const result2 = ensureValidSpecId(frontmatterWithUndefined)
+
+      expect(result1.spec_id).toBeDefined()
+      expect(result2.spec_id).toBeDefined()
+      expect(result1.spec_id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
+      expect(result2.spec_id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
+    })
+  })
+
+  describe('integration with existing frontmatter functions', () => {
+    test('works with typical frontmatter workflow', () => {
+      // Start with frontmatter without UUID
+      let frontmatter: Partial<SpecFileFrontmatter> = {
+        sync_status: 'draft',
+        auto_sync: true,
+      }
+
+      // Ensure valid spec_id
+      frontmatter = ensureValidSpecId(frontmatter)
+      expect(frontmatter.spec_id).toBeDefined()
+
+      // Validate the spec_id
+      const validatedSpecId = validateSpecId(frontmatter.spec_id!)
+      expect(validatedSpecId).toBe(frontmatter.spec_id)
+
+      // Safe validation should also work
+      const safeValidatedSpecId = safeValidateSpecId(frontmatter.spec_id!)
+      expect(safeValidatedSpecId).toBe(frontmatter.spec_id)
+    })
+
+    test('handles edge case with non-standard frontmatter structure', () => {
+      const weirdFrontmatter = {
+        spec_id: 123 as any, // Wrong type
+        extraProperty: 'should be preserved',
+        nested: {
+          property: 'also preserved',
+        },
+      }
+
+      const result = ensureValidSpecId(weirdFrontmatter)
+
+      expect(result.spec_id).toBeDefined()
+      expect(result.spec_id).not.toBe(123)
+      expect(result.spec_id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
+      expect((result as any).extraProperty).toBe('should be preserved')
+      expect((result as any).nested).toEqual({ property: 'also preserved' })
+    })
+  })
+})

--- a/plugins/sync/test/core/frontmatter.test.ts
+++ b/plugins/sync/test/core/frontmatter.test.ts
@@ -203,7 +203,7 @@ describe('frontmatter utilities', () => {
       expect(result.frontmatter.sync_hash).toBeDefined()
     })
 
-    test('should generate spec_id if missing', () => {
+    test('should not generate spec_id if missing (generation moved to SpecScanner)', () => {
       const originalFile: SpecFile = {
         path: '/test/spec.md',
         filename: 'spec.md',
@@ -214,8 +214,8 @@ describe('frontmatter utilities', () => {
 
       const result = updateFrontmatter(originalFile, {})
 
-      expect(result.frontmatter.spec_id).toBeDefined()
-      expect(result.frontmatter.spec_id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
+      // spec_id generation now happens in SpecScanner, not updateFrontmatter
+      expect(result.frontmatter.spec_id).toBeUndefined()
     })
 
     test('should preserve existing spec_id', () => {

--- a/plugins/sync/test/core/scanner-uuid-simple.test.ts
+++ b/plugins/sync/test/core/scanner-uuid-simple.test.ts
@@ -1,0 +1,262 @@
+import { promises as fs } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { isValidUuid } from '../../src/adapters/github/uuid-utils'
+import { SpecScanner } from '../../src/core/scanner'
+
+describe('SpecScanner UUID Generation (Real FS)', () => {
+  let testDir: string
+  let specsDir: string
+  let scanner: SpecScanner
+
+  beforeEach(async () => {
+    testDir = await fs.mkdtemp(path.join(tmpdir(), 'scanner-uuid-test-'))
+    specsDir = path.join(testDir, 'specs')
+    await fs.mkdir(specsDir, { recursive: true })
+    scanner = new SpecScanner(specsDir)
+  })
+
+  afterEach(async () => {
+    await fs.rm(testDir, { recursive: true, force: true })
+  })
+
+  const createSpecDirectory = async (dirName: string, specContent: string) => {
+    const specDirPath = path.join(specsDir, dirName)
+    await fs.mkdir(specDirPath, { recursive: true })
+    await fs.writeFile(path.join(specDirPath, 'spec.md'), specContent)
+    return specDirPath
+  }
+
+  const readSpecFile = async (dirName: string): Promise<string> => {
+    return fs.readFile(path.join(specsDir, dirName, 'spec.md'), 'utf-8')
+  }
+
+  test('generates UUID for specs without spec_id', async () => {
+    const specContentWithoutUuid = `---
+title: Test Feature
+sync_status: draft
+---
+
+# Test Feature
+
+This is a test feature spec.`
+
+    await createSpecDirectory('001-test-feature', specContentWithoutUuid)
+
+    const specs = await scanner.scanAll()
+
+    expect(specs).toHaveLength(1)
+    expect(specs[0].name).toBe('001-test-feature')
+
+    const specFile = specs[0].files.get('spec.md')
+    expect(specFile).toBeDefined()
+    expect(specFile!.frontmatter.spec_id).toBeDefined()
+    expect(typeof specFile!.frontmatter.spec_id).toBe('string')
+
+    // Verify UUID format
+    expect(isValidUuid(specFile!.frontmatter.spec_id || '')).toBe(true)
+
+    // Verify UUID was persisted to disk
+    const updatedContent = await readSpecFile('001-test-feature')
+    expect(updatedContent).toContain('spec_id:')
+    expect(updatedContent).toContain(specFile!.frontmatter.spec_id)
+  })
+
+  test('preserves existing UUIDs', async () => {
+    const existingUuid = '550e8400-e29b-41d4-a716-446655440000'
+    const specContentWithUuid = `---
+title: Test Feature
+sync_status: draft
+spec_id: ${existingUuid}
+---
+
+# Test Feature
+
+This is a test feature spec.`
+
+    await createSpecDirectory('001-test-feature', specContentWithUuid)
+
+    const specs = await scanner.scanAll()
+
+    expect(specs).toHaveLength(1)
+    const specFile = specs[0].files.get('spec.md')
+    expect(specFile!.frontmatter.spec_id).toBe(existingUuid)
+
+    // Verify file content wasn't changed
+    const contentAfter = await readSpecFile('001-test-feature')
+    expect(contentAfter).toContain(existingUuid)
+  })
+
+  test('ensures UUID uniqueness across multiple specs', async () => {
+    const specContent1 = `---
+title: Feature 1
+---
+# Feature 1`
+
+    const specContent2 = `---
+title: Feature 2
+---
+# Feature 2`
+
+    await createSpecDirectory('001-feature-1', specContent1)
+    await createSpecDirectory('002-feature-2', specContent2)
+
+    const specs = await scanner.scanAll()
+
+    expect(specs).toHaveLength(2)
+
+    const uuid1 = specs[0].files.get('spec.md')!.frontmatter.spec_id
+    const uuid2 = specs[1].files.get('spec.md')!.frontmatter.spec_id
+
+    // UUIDs should be different
+    expect(uuid1).not.toBe(uuid2)
+    expect(uuid1).toBeDefined()
+    expect(uuid2).toBeDefined()
+    expect(isValidUuid(uuid1 || '')).toBe(true)
+    expect(isValidUuid(uuid2 || '')).toBe(true)
+  })
+
+  test('only generates UUIDs for spec.md files', async () => {
+    const specContent = `---
+title: Main Spec
+---
+# Main Spec`
+
+    const planContent = `---
+title: Implementation Plan
+---
+# Plan`
+
+    const specDirPath = path.join(specsDir, '001-test-feature')
+    await fs.mkdir(specDirPath, { recursive: true })
+    await fs.writeFile(path.join(specDirPath, 'spec.md'), specContent)
+    await fs.writeFile(path.join(specDirPath, 'plan.md'), planContent)
+
+    const specs = await scanner.scanAll()
+
+    const specFile = specs[0].files.get('spec.md')
+    const planFile = specs[0].files.get('plan.md')
+
+    // spec.md should have UUID generated
+    expect(specFile!.frontmatter.spec_id).toBeDefined()
+    expect(isValidUuid(specFile!.frontmatter.spec_id || '')).toBe(true)
+
+    // plan.md should NOT have UUID generated
+    expect(planFile!.frontmatter.spec_id).toBeUndefined()
+  })
+
+  test('handles specs with empty frontmatter', async () => {
+    const contentOnlySpec = `# Content Only Feature
+
+This spec has no frontmatter initially.`
+
+    await createSpecDirectory('003-content-only', contentOnlySpec)
+
+    const specs = await scanner.scanAll()
+    const spec = specs[0]
+    const specFile = spec.files.get('spec.md')
+
+    // Should have generated UUID and basic frontmatter
+    expect(specFile!.frontmatter.spec_id).toBeDefined()
+    expect(isValidUuid(specFile!.frontmatter.spec_id || '')).toBe(true)
+
+    // Verify file structure after migration
+    const updatedContent = await readSpecFile('003-content-only')
+    expect(updatedContent).toContain('---')
+    expect(updatedContent).toContain('spec_id:')
+    expect(updatedContent).toContain('# Content Only Feature')
+  })
+
+  test('persists UUID across multiple scans', async () => {
+    const specContent = `---
+title: Persistence Test
+---
+# Persistence Test`
+
+    await createSpecDirectory('004-persistence-test', specContent)
+
+    // First scan
+    const firstScan = await scanner.scanAll()
+    const firstUuid = firstScan[0].files.get('spec.md')!.frontmatter.spec_id
+
+    // Second scan with same scanner
+    const secondScan = await scanner.scanAll()
+    const secondUuid = secondScan[0].files.get('spec.md')!.frontmatter.spec_id
+
+    // Third scan with new scanner instance
+    const newScanner = new SpecScanner(specsDir)
+    const thirdScan = await newScanner.scanAll()
+    const thirdUuid = thirdScan[0].files.get('spec.md')!.frontmatter.spec_id
+
+    expect(firstUuid).toBe(secondUuid)
+    expect(secondUuid).toBe(thirdUuid)
+    expect(isValidUuid(firstUuid || '')).toBe(true)
+  })
+
+  test('scanSpec method generates UUID', async () => {
+    const specContentWithoutUuid = `---
+title: Single Spec
+---
+# Single Spec`
+
+    const specPath = await createSpecDirectory('005-single-spec', specContentWithoutUuid)
+
+    const spec = await scanner.scanSpec(specPath)
+
+    expect(spec).toBeDefined()
+    const specFile = spec!.files.get('spec.md')
+    expect(specFile!.frontmatter.spec_id).toBeDefined()
+    expect(isValidUuid(specFile!.frontmatter.spec_id || '')).toBe(true)
+
+    // Verify persistence
+    const updatedContent = await readSpecFile('005-single-spec')
+    expect(updatedContent).toContain(`spec_id: ${specFile!.frontmatter.spec_id}`)
+  })
+
+  test('handles complex frontmatter during UUID generation', async () => {
+    const complexSpecContent = `---
+title: Complex Feature
+sync_status: synced
+issue_type: parent
+auto_sync: true
+last_sync: "2024-01-15T14:30:00Z"
+sync_hash: "abc123def456"
+github:
+  issue_number: 555
+  labels:
+    - feature
+    - high-priority
+  assignees:
+    - developer1
+jira:
+  issue_key: "PROJ-123"
+---
+
+# Complex Feature
+
+This spec has complex frontmatter.`
+
+    await createSpecDirectory('006-complex', complexSpecContent)
+
+    const specs = await scanner.scanAll()
+    const spec = specs[0]
+    const specFile = spec.files.get('spec.md')
+
+    // Should have UUID added
+    expect(specFile!.frontmatter.spec_id).toBeDefined()
+    expect(isValidUuid(specFile!.frontmatter.spec_id || '')).toBe(true)
+
+    // Should preserve all existing fields
+    expect(specFile!.frontmatter.title).toBe('Complex Feature')
+    expect(specFile!.frontmatter.sync_status).toBe('synced')
+    expect(specFile!.frontmatter.github?.issue_number).toBe(555)
+    expect(specFile!.frontmatter.jira?.issue_key).toBe('PROJ-123')
+
+    // Verify persistence maintains structure
+    const persistedContent = await readSpecFile('006-complex')
+    expect(persistedContent).toContain('title: Complex Feature')
+    expect(persistedContent).toContain('issue_number: 555')
+    expect(persistedContent).toContain('issue_key: "PROJ-123"')
+  })
+})

--- a/plugins/sync/test/core/scanner-uuid.test.ts
+++ b/plugins/sync/test/core/scanner-uuid.test.ts
@@ -1,0 +1,471 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { parseMarkdownWithFrontmatter } from '../../src/core/frontmatter'
+import { SpecScanner } from '../../src/core/scanner'
+
+// Mock filesystem operations
+const mockReaddir = mock()
+const mockReadFile = mock()
+const mockWriteFile = mock()
+const mockMkdir = mock()
+
+// Mock the fs module
+mock.module('node:fs', () => ({
+  promises: {
+    readdir: mockReaddir,
+    readFile: mockReadFile,
+    writeFile: mockWriteFile,
+    mkdir: mockMkdir,
+  },
+}))
+
+describe('SpecScanner UUID Generation', () => {
+  let scanner: SpecScanner
+  const testSpecsRoot = '/test/specs'
+
+  beforeEach(() => {
+    scanner = new SpecScanner(testSpecsRoot)
+    mockReaddir.mockClear()
+    mockReadFile.mockClear()
+    mockWriteFile.mockClear()
+    mockMkdir.mockClear()
+  })
+
+  afterEach(() => {
+    mock.restore()
+  })
+
+  describe('UUID generation for specs without spec_id', () => {
+    test('generates UUID for specs without spec_id', async () => {
+      const specContentWithoutUuid = `---
+title: Test Feature
+sync_status: draft
+---
+
+# Test Feature
+
+This is a test feature spec.`
+
+      const _specWithUuid = `---
+title: Test Feature
+sync_status: draft
+spec_id: 550e8400-e29b-41d4-a716-446655440000
+---
+
+# Test Feature
+
+This is a test feature spec.`
+
+      // Mock directory structure
+      mockReaddir
+        .mockResolvedValueOnce([
+          { name: '001-test-feature', isDirectory: () => true },
+        ])
+        .mockResolvedValueOnce([
+          { name: 'spec.md', isFile: () => true, isDirectory: () => false },
+        ])
+
+      // Mock reading the spec file without UUID
+      mockReadFile.mockResolvedValueOnce(specContentWithoutUuid)
+
+      // Mock successful write
+      mockWriteFile.mockResolvedValueOnce(undefined)
+
+      const specs = await scanner.scanAll()
+
+      expect(specs).toHaveLength(1)
+      expect(specs[0].name).toBe('001-test-feature')
+
+      const specFile = specs[0].files.get('spec.md')
+      expect(specFile).toBeDefined()
+      expect(specFile!.frontmatter.spec_id).toBeDefined()
+      expect(typeof specFile!.frontmatter.spec_id).toBe('string')
+
+      // Verify UUID format
+      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      expect(specFile!.frontmatter.spec_id).toMatch(uuidRegex)
+
+      // Verify write was called to persist UUID
+      expect(mockWriteFile).toHaveBeenCalledTimes(1)
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        expect.stringContaining('spec.md'),
+        expect.stringContaining('spec_id:'),
+        'utf-8',
+      )
+    })
+
+    test('preserves existing UUIDs', async () => {
+      const existingUuid = '550e8400-e29b-41d4-a716-446655440000'
+      const specContentWithUuid = `---
+title: Test Feature
+sync_status: draft
+spec_id: ${existingUuid}
+---
+
+# Test Feature
+
+This is a test feature spec.`
+
+      // Mock directory structure
+      mockReaddir
+        .mockResolvedValueOnce([
+          { name: '001-test-feature', isDirectory: () => true },
+        ])
+        .mockResolvedValueOnce([
+          { name: 'spec.md', isFile: () => true, isDirectory: () => false },
+        ])
+
+      // Mock reading the spec file with existing UUID
+      mockReadFile.mockResolvedValueOnce(specContentWithUuid)
+
+      const specs = await scanner.scanAll()
+
+      expect(specs).toHaveLength(1)
+      const specFile = specs[0].files.get('spec.md')
+      expect(specFile!.frontmatter.spec_id).toBe(existingUuid)
+
+      // Verify write was NOT called since UUID already exists
+      expect(mockWriteFile).not.toHaveBeenCalled()
+    })
+
+    test('persists UUID to disk immediately', async () => {
+      const specContentWithoutUuid = `---
+title: Test Feature
+sync_status: draft
+---
+
+# Test Feature Content`
+
+      mockReaddir
+        .mockResolvedValueOnce([
+          { name: '001-test-feature', isDirectory: () => true },
+        ])
+        .mockResolvedValueOnce([
+          { name: 'spec.md', isFile: () => true, isDirectory: () => false },
+        ])
+
+      mockReadFile.mockResolvedValueOnce(specContentWithoutUuid)
+      mockWriteFile.mockResolvedValueOnce(undefined)
+
+      await scanner.scanAll()
+
+      // Verify write was called exactly once
+      expect(mockWriteFile).toHaveBeenCalledTimes(1)
+
+      // Verify the written content includes a UUID
+      const [filePath, content] = mockWriteFile.mock.calls[0]
+      expect(filePath).toContain('spec.md')
+      expect(content).toContain('spec_id:')
+
+      // Parse and verify the UUID is valid
+      const parsedFile = parseMarkdownWithFrontmatter(content as string, filePath as string)
+      expect(parsedFile.frontmatter.spec_id).toBeDefined()
+      expect(typeof parsedFile.frontmatter.spec_id).toBe('string')
+
+      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      expect(parsedFile.frontmatter.spec_id).toMatch(uuidRegex)
+    })
+
+    test('handles file write errors gracefully', async () => {
+      const specContentWithoutUuid = `---
+title: Test Feature
+---
+
+# Test Feature`
+
+      mockReaddir
+        .mockResolvedValueOnce([
+          { name: '001-test-feature', isDirectory: () => true },
+        ])
+        .mockResolvedValueOnce([
+          { name: 'spec.md', isFile: () => true, isDirectory: () => false },
+        ])
+
+      mockReadFile.mockResolvedValueOnce(specContentWithoutUuid)
+      mockWriteFile.mockRejectedValueOnce(new Error('Permission denied'))
+
+      // Mock console.error to verify error handling
+      const consoleErrorMock = mock(console, 'error')
+
+      const specs = await scanner.scanAll()
+
+      // Should still return the spec with in-memory UUID
+      expect(specs).toHaveLength(1)
+      const specFile = specs[0].files.get('spec.md')
+      expect(specFile!.frontmatter.spec_id).toBeDefined()
+
+      // Should have logged the error
+      expect(consoleErrorMock).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to persist spec_id for'),
+        expect.any(Error),
+      )
+
+      consoleErrorMock.mockRestore()
+    })
+
+    test('ensures UUID uniqueness across multiple scans', async () => {
+      const specContent1 = `---
+title: Feature 1
+---
+# Feature 1`
+
+      const specContent2 = `---
+title: Feature 2
+---
+# Feature 2`
+
+      // First scan
+      mockReaddir
+        .mockResolvedValueOnce([
+          { name: '001-feature-1', isDirectory: () => true },
+        ])
+        .mockResolvedValueOnce([
+          { name: 'spec.md', isFile: () => true, isDirectory: () => false },
+        ])
+
+      mockReadFile.mockResolvedValueOnce(specContent1)
+      mockWriteFile.mockResolvedValueOnce(undefined)
+
+      const specs1 = await scanner.scanAll()
+      const uuid1 = specs1[0].files.get('spec.md')!.frontmatter.spec_id
+
+      // Clear mocks for second scan
+      mockReaddir.mockClear()
+      mockReadFile.mockClear()
+      mockWriteFile.mockClear()
+
+      // Second scan
+      mockReaddir
+        .mockResolvedValueOnce([
+          { name: '002-feature-2', isDirectory: () => true },
+        ])
+        .mockResolvedValueOnce([
+          { name: 'spec.md', isFile: () => true, isDirectory: () => false },
+        ])
+
+      mockReadFile.mockResolvedValueOnce(specContent2)
+      mockWriteFile.mockResolvedValueOnce(undefined)
+
+      const specs2 = await scanner.scanAll()
+      const uuid2 = specs2[0].files.get('spec.md')!.frontmatter.spec_id
+
+      // UUIDs should be different
+      expect(uuid1).not.toBe(uuid2)
+      expect(uuid1).toBeDefined()
+      expect(uuid2).toBeDefined()
+    })
+
+    test('handles race condition protection', async () => {
+      const specContentWithoutUuid = `---
+title: Test Feature
+---
+# Test Feature`
+
+      mockReaddir
+        .mockResolvedValueOnce([
+          { name: '001-test-feature', isDirectory: () => true },
+        ])
+        .mockResolvedValueOnce([
+          { name: 'spec.md', isFile: () => true, isDirectory: () => false },
+        ])
+
+      mockReadFile.mockResolvedValueOnce(specContentWithoutUuid)
+
+      // Simulate slow write operation
+      let writeResolver: (value: any) => void
+      const writePromise = new Promise((resolve) => {
+        writeResolver = resolve
+      })
+      mockWriteFile.mockReturnValueOnce(writePromise)
+
+      // Start first scan
+      const scanPromise1 = scanner.scanAll()
+
+      // Start second scan immediately (simulating race condition)
+      const scanPromise2 = scanner.scanAll()
+
+      // Resolve write operation
+      writeResolver!(undefined)
+
+      const [specs1, specs2] = await Promise.all([scanPromise1, scanPromise2])
+
+      // Both should have valid UUIDs
+      const uuid1 = specs1[0].files.get('spec.md')!.frontmatter.spec_id
+      const uuid2 = specs2[0].files.get('spec.md')!.frontmatter.spec_id
+
+      expect(uuid1).toBeDefined()
+      expect(uuid2).toBeDefined()
+
+      // Note: In current implementation, they might be different UUIDs
+      // This is acceptable behavior for the race condition scenario
+    })
+
+    test('only generates UUIDs for spec.md files', async () => {
+      const specContent = `---
+title: Main Spec
+---
+# Main Spec`
+
+      const planContent = `---
+title: Implementation Plan
+---
+# Plan`
+
+      mockReaddir
+        .mockResolvedValueOnce([
+          { name: '001-test-feature', isDirectory: () => true },
+        ])
+        .mockResolvedValueOnce([
+          { name: 'spec.md', isFile: () => true, isDirectory: () => false },
+          { name: 'plan.md', isFile: () => true, isDirectory: () => false },
+        ])
+
+      mockReadFile
+        .mockResolvedValueOnce(specContent)
+        .mockResolvedValueOnce(planContent)
+
+      mockWriteFile.mockResolvedValueOnce(undefined)
+
+      const specs = await scanner.scanAll()
+
+      const specFile = specs[0].files.get('spec.md')
+      const planFile = specs[0].files.get('plan.md')
+
+      // spec.md should have UUID generated
+      expect(specFile!.frontmatter.spec_id).toBeDefined()
+
+      // plan.md should NOT have UUID generated
+      expect(planFile!.frontmatter.spec_id).toBeUndefined()
+
+      // Only one write call for spec.md
+      expect(mockWriteFile).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('scanSpec method UUID handling', () => {
+    test('generates UUID when scanning single spec', async () => {
+      const specContentWithoutUuid = `---
+title: Single Spec
+---
+# Single Spec`
+
+      mockReadFile.mockResolvedValueOnce(specContentWithoutUuid)
+      mockWriteFile.mockResolvedValueOnce(undefined)
+
+      // Mock the full directory scan that scanSpec delegates to
+      mockReaddir.mockResolvedValueOnce([
+        { name: 'spec.md', isFile: () => true, isDirectory: () => false },
+      ])
+      mockReadFile.mockResolvedValueOnce(specContentWithoutUuid) // Second call for full scan
+
+      const spec = await scanner.scanSpec('/test/specs/001-feature')
+
+      expect(spec).toBeDefined()
+      const specFile = spec!.files.get('spec.md')
+      expect(specFile!.frontmatter.spec_id).toBeDefined()
+
+      // Verify write was called
+      expect(mockWriteFile).toHaveBeenCalled()
+    })
+
+    test('preserves existing UUID when scanning single spec', async () => {
+      const existingUuid = '550e8400-e29b-41d4-a716-446655440000'
+      const specContentWithUuid = `---
+title: Single Spec
+spec_id: ${existingUuid}
+---
+# Single Spec`
+
+      mockReadFile.mockResolvedValueOnce(specContentWithUuid)
+
+      // Mock the full directory scan
+      mockReaddir.mockResolvedValueOnce([
+        { name: 'spec.md', isFile: () => true, isDirectory: () => false },
+      ])
+      mockReadFile.mockResolvedValueOnce(specContentWithUuid)
+
+      const spec = await scanner.scanSpec('/test/specs/001-feature')
+
+      expect(spec).toBeDefined()
+      const specFile = spec!.files.get('spec.md')
+      expect(specFile!.frontmatter.spec_id).toBe(existingUuid)
+
+      // No write should be called
+      expect(mockWriteFile).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('error handling and edge cases', () => {
+    test('handles missing spec.md file gracefully', async () => {
+      mockReaddir
+        .mockResolvedValueOnce([
+          { name: '001-test-feature', isDirectory: () => true },
+        ])
+        .mockResolvedValueOnce([
+          { name: 'plan.md', isFile: () => true, isDirectory: () => false },
+        ])
+
+      mockReadFile.mockResolvedValueOnce('# Plan content')
+
+      const specs = await scanner.scanAll()
+
+      expect(specs).toHaveLength(1)
+      expect(specs[0].files.has('spec.md')).toBe(false)
+      expect(specs[0].files.has('plan.md')).toBe(true)
+
+      // No UUID should be generated since there's no spec.md
+      expect(mockWriteFile).not.toHaveBeenCalled()
+    })
+
+    test('handles malformed frontmatter gracefully', async () => {
+      const malformedContent = `---
+title: Test
+invalid_yaml: [unclosed array
+---
+# Content`
+
+      mockReaddir
+        .mockResolvedValueOnce([
+          { name: '001-test-feature', isDirectory: () => true },
+        ])
+        .mockResolvedValueOnce([
+          { name: 'spec.md', isFile: () => true, isDirectory: () => false },
+        ])
+
+      mockReadFile.mockResolvedValueOnce(malformedContent)
+
+      // This should handle the parsing error gracefully
+      // The implementation may throw or return null depending on error handling
+      await expect(scanner.scanAll()).resolves.not.toThrow()
+    })
+
+    test('handles very large spec files efficiently', async () => {
+      const largeContent = `---
+title: Large Spec
+---
+# Large Spec
+
+${'A'.repeat(100000)}` // 100KB of content
+
+      mockReaddir
+        .mockResolvedValueOnce([
+          { name: '001-large-feature', isDirectory: () => true },
+        ])
+        .mockResolvedValueOnce([
+          { name: 'spec.md', isFile: () => true, isDirectory: () => false },
+        ])
+
+      mockReadFile.mockResolvedValueOnce(largeContent)
+      mockWriteFile.mockResolvedValueOnce(undefined)
+
+      const startTime = Date.now()
+      const specs = await scanner.scanAll()
+      const endTime = Date.now()
+
+      expect(specs).toHaveLength(1)
+      expect(specs[0].files.get('spec.md')!.frontmatter.spec_id).toBeDefined()
+
+      // Should complete in reasonable time (adjust threshold as needed)
+      expect(endTime - startTime).toBeLessThan(1000)
+    })
+  })
+})

--- a/plugins/sync/test/fixtures/uuid-test-data/github-issue-with-uuid.json
+++ b/plugins/sync/test/fixtures/uuid-test-data/github-issue-with-uuid.json
@@ -1,0 +1,54 @@
+{
+  "number": 123,
+  "title": "Feature With UUID - Test Issue",
+  "body": "<!-- spec_id: 550e8400-e29b-41d4-a716-446655440000 -->\n\n# Feature Implementation\n\nThis is a GitHub issue that contains UUID metadata in its body.\n\n## Overview\n\nThe UUID metadata is embedded as an HTML comment at the beginning of the issue body, making it invisible to users but parseable by the sync system.\n\n## Implementation Details\n\n- Feature A: Core functionality\n- Feature B: Extended capabilities\n- Feature C: Integration points\n\n## Testing\n\n- Unit tests: ✅ Completed\n- Integration tests: 🔄 In Progress\n- E2E tests: ⏳ Pending\n\n## Dependencies\n\n- Dependency 1: Core library\n- Dependency 2: Testing framework\n- Dependency 3: UI components",
+  "state": "open",
+  "created_at": "2024-01-15T09:00:00Z",
+  "updated_at": "2024-01-15T10:30:00Z",
+  "closed_at": null,
+  "labels": [
+    {
+      "name": "feature",
+      "color": "0052cc",
+      "description": "New feature or request"
+    },
+    {
+      "name": "uuid-enabled",
+      "color": "00ff00",
+      "description": "Issue with UUID metadata"
+    },
+    {
+      "name": "spec",
+      "color": "ff6600",
+      "description": "Generated from spec file"
+    }
+  ],
+  "assignees": [
+    {
+      "login": "developer1",
+      "avatar_url": "https://github.com/images/avatars/developer1",
+      "html_url": "https://github.com/developer1"
+    },
+    {
+      "login": "developer2",
+      "avatar_url": "https://github.com/images/avatars/developer2",
+      "html_url": "https://github.com/developer2"
+    }
+  ],
+  "milestone": {
+    "number": 1,
+    "title": "v1.0.0 Release",
+    "description": "First major release",
+    "state": "open",
+    "due_on": "2024-03-01T00:00:00Z"
+  },
+  "comments": 3,
+  "author_association": "OWNER",
+  "html_url": "https://github.com/test-owner/test-repo/issues/123",
+  "repository_url": "https://api.github.com/repos/test-owner/test-repo",
+  "user": {
+    "login": "developer1",
+    "avatar_url": "https://github.com/images/avatars/developer1",
+    "html_url": "https://github.com/developer1"
+  }
+}

--- a/plugins/sync/test/fixtures/uuid-test-data/github-issue-without-uuid.json
+++ b/plugins/sync/test/fixtures/uuid-test-data/github-issue-without-uuid.json
@@ -1,0 +1,49 @@
+{
+  "number": 456,
+  "title": "Legacy Feature - No UUID",
+  "body": "# Legacy Feature Implementation\n\nThis is a GitHub issue that was created before UUID support was added to the sync system.\n\n## Overview\n\nThis issue represents the legacy format where issues were identified solely by their issue number.\n\n## Implementation Tasks\n\n- [x] Core functionality implementation\n- [x] Basic testing\n- [ ] Integration with new UUID system\n- [ ] Migration to UUID-based identification\n\n## Migration Notes\n\nWhen this issue is next synced with a spec that has a UUID, the sync system should:\n\n1. Embed the UUID metadata in this issue body\n2. Update the issue to include the UUID comment\n3. Maintain all existing content\n\n## Current Status\n\n- **Created**: Before UUID system\n- **Last Updated**: Manual edit\n- **Sync Status**: Pending migration\n- **UUID Status**: Not present",
+  "state": "open",
+  "created_at": "2023-12-01T14:30:00Z",
+  "updated_at": "2023-12-15T16:45:00Z",
+  "closed_at": null,
+  "labels": [
+    {
+      "name": "feature",
+      "color": "0052cc",
+      "description": "New feature or request"
+    },
+    {
+      "name": "legacy",
+      "color": "cccccc",
+      "description": "Legacy issue format"
+    },
+    {
+      "name": "migration-needed",
+      "color": "ffaa00",
+      "description": "Needs migration to new format"
+    }
+  ],
+  "assignees": [
+    {
+      "login": "legacy-developer",
+      "avatar_url": "https://github.com/images/avatars/legacy-developer",
+      "html_url": "https://github.com/legacy-developer"
+    }
+  ],
+  "milestone": {
+    "number": 2,
+    "title": "Legacy Migration",
+    "description": "Migration of legacy issues to UUID system",
+    "state": "open",
+    "due_on": "2024-02-15T00:00:00Z"
+  },
+  "comments": 8,
+  "author_association": "COLLABORATOR",
+  "html_url": "https://github.com/test-owner/test-repo/issues/456",
+  "repository_url": "https://api.github.com/repos/test-owner/test-repo",
+  "user": {
+    "login": "legacy-developer",
+    "avatar_url": "https://github.com/images/avatars/legacy-developer",
+    "html_url": "https://github.com/legacy-developer"
+  }
+}

--- a/plugins/sync/test/fixtures/uuid-test-data/spec-with-invalid-uuid.md
+++ b/plugins/sync/test/fixtures/uuid-test-data/spec-with-invalid-uuid.md
@@ -1,0 +1,48 @@
+---
+title: Feature With Invalid UUID
+spec_id: "not-a-valid-uuid-format"
+sync_status: draft
+issue_type: parent
+auto_sync: true
+github:
+  issue_number: 789
+  labels:
+    - feature
+    - needs-migration
+---
+
+# Feature With Invalid UUID
+
+This spec has an invalid UUID format that should be replaced during migration.
+
+## Overview
+
+This represents a spec that may have been manually edited or corrupted, resulting in an invalid UUID format.
+
+## Current Issues
+
+- **Invalid UUID**: `not-a-valid-uuid-format`
+- **Expected Format**: UUID v4 (xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx)
+- **Migration Required**: Yes
+
+## Requirements
+
+- **REQ-001**: System must detect invalid UUID format
+- **REQ-002**: System must replace with valid UUID
+- **REQ-003**: System must preserve other metadata
+- **REQ-004**: System must persist corrected UUID to disk
+
+## Expected Migration Behavior
+
+1. Scanner detects invalid UUID format
+2. Generates new valid UUID v4
+3. Preserves all other frontmatter fields
+4. Writes updated content to disk
+5. Logs migration action
+
+## Testing Scenarios
+
+1. **Detection Test**: Invalid format should be identified
+2. **Replacement Test**: New valid UUID should be generated
+3. **Preservation Test**: Other metadata should remain unchanged
+4. **Persistence Test**: Changes should be saved to file

--- a/plugins/sync/test/fixtures/uuid-test-data/spec-with-valid-uuid.md
+++ b/plugins/sync/test/fixtures/uuid-test-data/spec-with-valid-uuid.md
@@ -1,0 +1,50 @@
+---
+title: Feature With Valid UUID
+spec_id: 550e8400-e29b-41d4-a716-446655440000
+sync_status: synced
+issue_type: parent
+auto_sync: true
+last_sync: "2024-01-15T10:30:00Z"
+sync_hash: "abc123def456"
+github:
+  issue_number: 456
+  updated_at: "2024-01-15T10:25:00Z"
+  labels:
+    - feature
+    - uuid-enabled
+  assignees:
+    - developer2
+jira:
+  issue_key: "PROJ-456"
+  epic_key: "PROJ-100"
+---
+
+# Feature With Valid UUID
+
+This spec already has a valid UUID and should not be modified during scanning.
+
+## Overview
+
+This represents a modern spec that was created with UUID support from the beginning.
+
+## UUID Information
+
+- **Spec ID**: `550e8400-e29b-41d4-a716-446655440000`
+- **Format**: UUID v4
+- **Purpose**: Primary identifier for cross-platform sync
+
+## Requirements
+
+- **REQ-001**: UUID must remain unchanged during scans
+- **REQ-002**: All existing metadata must be preserved
+- **REQ-003**: Sync operations should use UUID as primary identifier
+
+## Sync Status
+
+This spec is currently synced with remote systems and should maintain its UUID consistency across all platforms.
+
+## Testing Scenarios
+
+1. **Stability Test**: UUID should never change
+2. **Priority Test**: UUID should take precedence over issue_number
+3. **Consistency Test**: Multiple scans should yield identical results

--- a/plugins/sync/test/fixtures/uuid-test-data/spec-without-uuid.md
+++ b/plugins/sync/test/fixtures/uuid-test-data/spec-without-uuid.md
@@ -1,0 +1,37 @@
+---
+title: Feature Without UUID
+sync_status: draft
+issue_type: parent
+auto_sync: true
+github:
+  issue_number: 123
+  labels:
+    - feature
+    - enhancement
+  assignees:
+    - developer1
+---
+
+# Feature Without UUID
+
+This is a test spec that was created before UUID support was added to the system.
+
+## Overview
+
+This feature demonstrates the migration path for existing specs that only have issue numbers but no UUID identifiers.
+
+## Requirements
+
+- **REQ-001**: System must generate UUID for specs without one
+- **REQ-002**: System must preserve existing metadata
+- **REQ-003**: System must persist UUID to disk immediately
+
+## Implementation Notes
+
+The scanner should automatically detect specs without UUIDs and generate them during the scanning process.
+
+## Testing Scenarios
+
+1. **Migration Test**: Verify UUID is generated and persisted
+2. **Preservation Test**: Ensure existing frontmatter is maintained
+3. **Consistency Test**: UUID should remain stable across scans

--- a/plugins/sync/test/integration/uuid-integration.test.ts
+++ b/plugins/sync/test/integration/uuid-integration.test.ts
@@ -1,0 +1,477 @@
+import { promises as fs } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { embedUuidInIssueBody, extractUuidFromIssueBody } from '../../src/adapters/github/uuid-utils'
+import { SpecScanner } from '../../src/core/scanner'
+import { SyncEngine } from '../../src/core/sync-engine'
+
+describe('UUID Integration Tests', () => {
+  let testDir: string
+  let specsDir: string
+  let scanner: SpecScanner
+  let mockAdapter: any
+  let syncEngine: SyncEngine
+
+  const validUuid1 = '550e8400-e29b-41d4-a716-446655440000'
+  const validUuid2 = 'f47ac10b-58cc-4372-a567-0e02b2c3d479'
+
+  beforeEach(async () => {
+    // Create temporary test directory
+    testDir = await fs.mkdtemp(path.join(tmpdir(), 'uuid-integration-test-'))
+    specsDir = path.join(testDir, 'specs')
+    await fs.mkdir(specsDir, { recursive: true })
+
+    scanner = new SpecScanner(specsDir)
+
+    // Create mock GitHub adapter
+    mockAdapter = {
+      platform: 'github',
+      searchIssueByUuid: mock(),
+      getIssue: mock(),
+      createIssue: mock(),
+      updateIssue: mock(),
+      push: mock(),
+      getStatus: mock(),
+      authenticate: mock().mockResolvedValue(true),
+      capabilities: mock().mockReturnValue({
+        supportsBatch: true,
+        supportsSubtasks: true,
+      }),
+    }
+
+    syncEngine = new SyncEngine(scanner, mockAdapter)
+  })
+
+  afterEach(async () => {
+    // Clean up test directory
+    await fs.rm(testDir, { recursive: true, force: true })
+  })
+
+  const createSpecDirectory = async (
+    dirName: string,
+    specContent: string,
+    otherFiles: Record<string, string> = {},
+  ) => {
+    const specDirPath = path.join(specsDir, dirName)
+    await fs.mkdir(specDirPath, { recursive: true })
+
+    // Write spec.md
+    await fs.writeFile(path.join(specDirPath, 'spec.md'), specContent)
+
+    // Write other files if provided
+    for (const [filename, content] of Object.entries(otherFiles)) {
+      await fs.writeFile(path.join(specDirPath, filename), content)
+    }
+
+    return specDirPath
+  }
+
+  test('end-to-end UUID generation and sync', async () => {
+    // Create a spec without UUID
+    const specContentWithoutUuid = `---
+title: Test Feature
+sync_status: draft
+---
+
+# Test Feature
+
+This is a comprehensive test of the UUID system.`
+
+    await createSpecDirectory('001-test-feature', specContentWithoutUuid)
+
+    // Mock successful remote operations
+    mockAdapter.searchIssueByUuid.mockResolvedValue(null)
+    mockAdapter.createIssue.mockResolvedValue({ id: 123, url: 'https://github.com/test/test/issues/123' })
+    mockAdapter.push.mockImplementation(async (spec) => {
+      const mainFile = spec.files.get('spec.md')
+      expect(mainFile?.frontmatter.spec_id).toBeDefined()
+      expect(typeof mainFile?.frontmatter.spec_id).toBe('string')
+
+      // Verify UUID format
+      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      expect(mainFile?.frontmatter.spec_id).toMatch(uuidRegex)
+
+      return { id: 123, type: 'parent', url: 'https://github.com/test/test/issues/123' }
+    })
+
+    // Scan specs (should generate UUID)
+    const specs = await scanner.scanAll()
+    expect(specs).toHaveLength(1)
+
+    const spec = specs[0]
+    const specFile = spec.files.get('spec.md')
+    expect(specFile?.frontmatter.spec_id).toBeDefined()
+
+    // Verify UUID was persisted to disk
+    const persistedContent = await fs.readFile(path.join(specsDir, '001-test-feature', 'spec.md'), 'utf-8')
+    expect(persistedContent).toContain('spec_id:')
+    expect(persistedContent).toContain(specFile?.frontmatter.spec_id)
+
+    // Sync to remote
+    await syncEngine.pushSpec(spec)
+
+    expect(mockAdapter.push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        files: expect.any(Map),
+      }),
+      undefined,
+    )
+  })
+
+  test('migration from issue_number to UUID priority', async () => {
+    // Create a spec with only issue_number (legacy format)
+    const legacySpecContent = `---
+title: Legacy Feature
+sync_status: synced
+github:
+  issue_number: 456
+---
+
+# Legacy Feature
+
+This spec was created before UUID support.`
+
+    await createSpecDirectory('002-legacy-feature', legacySpecContent)
+
+    // Mock remote issue without UUID
+    const remoteIssueWithoutUuid = {
+      number: 456,
+      title: 'Legacy Feature',
+      body: 'Legacy issue body without UUID metadata',
+      state: 'open',
+      labels: [],
+    }
+
+    mockAdapter.searchIssueByUuid.mockResolvedValue(null)
+    mockAdapter.getIssue.mockResolvedValue(remoteIssueWithoutUuid)
+    mockAdapter.updateIssue.mockResolvedValue(undefined)
+    mockAdapter.push.mockResolvedValue({ id: 456, type: 'parent', url: 'https://github.com/test/test/issues/456' })
+
+    // Scan specs (should generate UUID for legacy spec)
+    const specs = await scanner.scanAll()
+    const legacySpec = specs[0]
+    const specFile = legacySpec.files.get('spec.md')
+
+    // Should now have both UUID and issue_number
+    expect(specFile?.frontmatter.spec_id).toBeDefined()
+    expect(specFile?.frontmatter.github?.issue_number).toBe(456)
+
+    // Sync should use UUID-first logic but fall back to issue_number
+    await syncEngine.pushSpec(legacySpec)
+
+    expect(mockAdapter.push).toHaveBeenCalled()
+  })
+
+  test('cross-platform sync simulation', async () => {
+    // Simulate two developers working on the same spec
+    const sharedUuid = validUuid1
+
+    // Developer A creates spec with UUID
+    const devASpecContent = `---
+title: Shared Feature
+spec_id: ${sharedUuid}
+sync_status: draft
+---
+
+# Shared Feature
+
+Developer A's initial version.`
+
+    await createSpecDirectory('003-shared-feature', devASpecContent)
+
+    // Developer A pushes to remote
+    const remoteIssueWithUuid = {
+      number: 789,
+      title: 'Shared Feature',
+      body: embedUuidInIssueBody('Developer A\'s remote version', sharedUuid),
+      state: 'open',
+      labels: [],
+    }
+
+    mockAdapter.searchIssueByUuid.mockResolvedValue(remoteIssueWithUuid)
+    mockAdapter.push.mockResolvedValue({ id: 789, type: 'parent', url: 'https://github.com/test/test/issues/789' })
+
+    const specsA = await scanner.scanAll()
+    await syncEngine.pushSpec(specsA[0])
+
+    // Developer B pulls the same spec (simulate different directory structure)
+    const devBSpecContent = `---
+title: Shared Feature
+spec_id: ${sharedUuid}
+sync_status: synced
+github:
+  issue_number: 789
+---
+
+# Shared Feature
+
+Developer B's local changes.`
+
+    // Clear the test directory and recreate with Developer B's version
+    await fs.rm(path.join(specsDir, '003-shared-feature'), { recursive: true })
+    await createSpecDirectory('003-shared-feature-different-name', devBSpecContent)
+
+    // Developer B syncs - should find the same remote issue by UUID
+    const specsB = await scanner.scanAll()
+    const devBSpec = specsB[0]
+
+    mockAdapter.getStatus.mockResolvedValue({
+      status: 'synced',
+      hasChanges: false,
+      remoteId: 789,
+    })
+
+    const status = await syncEngine.getStatus(devBSpec)
+    expect(status.remoteId).toBe(789)
+  })
+
+  test('conflict resolution scenarios', async () => {
+    // Create spec with UUID that conflicts with remote
+    const localUuid = validUuid1
+    const remoteUuid = validUuid2
+
+    const conflictSpecContent = `---
+title: Conflict Feature
+spec_id: ${localUuid}
+sync_status: draft
+github:
+  issue_number: 999
+---
+
+# Conflict Feature
+
+Local changes that conflict with remote.`
+
+    await createSpecDirectory('004-conflict-feature', conflictSpecContent)
+
+    // Remote issue has different UUID
+    const remoteIssueWithDifferentUuid = {
+      number: 999,
+      title: 'Conflict Feature',
+      body: embedUuidInIssueBody('Remote content with different UUID', remoteUuid),
+      state: 'open',
+      labels: [],
+    }
+
+    mockAdapter.searchIssueByUuid.mockResolvedValue(null) // UUID search fails
+    mockAdapter.getIssue.mockResolvedValue(remoteIssueWithDifferentUuid) // Issue number points to different UUID
+
+    // Should detect UUID mismatch conflict
+    mockAdapter.getStatus.mockImplementation(async (spec) => {
+      const mainFile = spec.files.get('spec.md')
+      const uuid = mainFile?.frontmatter.spec_id
+      const issueNumber = mainFile?.frontmatter.github?.issue_number
+
+      if (uuid === localUuid && issueNumber === 999) {
+        return {
+          status: 'conflict',
+          hasChanges: true,
+          remoteId: 999,
+          conflicts: [`UUID mismatch: local=${uuid}, remote=${remoteUuid}`],
+        }
+      }
+
+      return { status: 'unknown', hasChanges: false }
+    })
+
+    const specs = await scanner.scanAll()
+    const conflictSpec = specs[0]
+
+    const status = await syncEngine.getStatus(conflictSpec)
+
+    expect(status.status).toBe('conflict')
+    expect(status.conflicts).toContain(
+      expect.stringMatching(/UUID mismatch.*local=.*remote=/),
+    )
+  })
+
+  test('batch operations with UUID', async () => {
+    // Create multiple specs with different UUID scenarios
+    const specs = [
+      {
+        name: '005-uuid-only',
+        content: `---
+title: UUID Only Feature
+spec_id: ${validUuid1}
+sync_status: draft
+---
+# UUID Only Feature`,
+      },
+      {
+        name: '006-issue-number-only',
+        content: `---
+title: Issue Number Only Feature
+sync_status: draft
+github:
+  issue_number: 111
+---
+# Issue Number Only Feature`,
+      },
+      {
+        name: '007-both-identifiers',
+        content: `---
+title: Both Identifiers Feature
+spec_id: ${validUuid2}
+sync_status: draft
+github:
+  issue_number: 222
+---
+# Both Identifiers Feature`,
+      },
+    ]
+
+    // Create all spec directories
+    for (const spec of specs) {
+      await createSpecDirectory(spec.name, spec.content)
+    }
+
+    // Mock remote responses
+    mockAdapter.searchIssueByUuid
+      .mockResolvedValueOnce({ number: 100, title: 'UUID Only', body: embedUuidInIssueBody('content', validUuid1) })
+      .mockResolvedValueOnce(null) // 006 has no UUID
+      .mockResolvedValueOnce({ number: 200, title: 'Both IDs', body: embedUuidInIssueBody('content', validUuid2) })
+
+    mockAdapter.getIssue
+      .mockResolvedValueOnce({ number: 111, title: 'Issue Number Only', body: 'content' }) // For 006
+
+    mockAdapter.push
+      .mockResolvedValueOnce({ id: 100, type: 'parent', url: 'url1' })
+      .mockResolvedValueOnce({ id: 111, type: 'parent', url: 'url2' })
+      .mockResolvedValueOnce({ id: 200, type: 'parent', url: 'url3' })
+
+    // Scan and sync all specs
+    const scannedSpecs = await scanner.scanAll()
+    expect(scannedSpecs).toHaveLength(3)
+
+    // All specs should now have UUIDs (generated for the ones that didn't have them)
+    for (const spec of scannedSpecs) {
+      const specFile = spec.files.get('spec.md')
+      expect(specFile?.frontmatter.spec_id).toBeDefined()
+    }
+
+    // Sync all specs
+    const results = await Promise.all(
+      scannedSpecs.map(spec => syncEngine.pushSpec(spec)),
+    )
+
+    expect(results).toHaveLength(3)
+    expect(mockAdapter.push).toHaveBeenCalledTimes(3)
+  })
+
+  test('UUID persistence and consistency', async () => {
+    // Create spec without UUID
+    const specContent = `---
+title: Persistence Test
+sync_status: draft
+---
+
+# Persistence Test
+
+Testing UUID persistence across multiple operations.`
+
+    await createSpecDirectory('008-persistence-test', specContent)
+
+    // First scan - should generate UUID
+    const firstScan = await scanner.scanAll()
+    const firstSpec = firstScan[0]
+    const firstUuid = firstSpec.files.get('spec.md')?.frontmatter.spec_id
+
+    expect(firstUuid).toBeDefined()
+
+    // Second scan of the same directory - should preserve UUID
+    const secondScan = await scanner.scanAll()
+    const secondSpec = secondScan[0]
+    const secondUuid = secondSpec.files.get('spec.md')?.frontmatter.spec_id
+
+    expect(secondUuid).toBe(firstUuid)
+
+    // Verify UUID is still in the file on disk
+    const persistedContent = await fs.readFile(
+      path.join(specsDir, '008-persistence-test', 'spec.md'),
+      'utf-8',
+    )
+    expect(persistedContent).toContain(`spec_id: ${firstUuid}`)
+
+    // Third scan with new scanner instance - should still preserve UUID
+    const newScanner = new SpecScanner(specsDir)
+    const thirdScan = await newScanner.scanAll()
+    const thirdSpec = thirdScan[0]
+    const thirdUuid = thirdSpec.files.get('spec.md')?.frontmatter.spec_id
+
+    expect(thirdUuid).toBe(firstUuid)
+  })
+
+  test('UUID extraction and embedding in issue bodies', async () => {
+    const testUuid = validUuid1
+    const specContent = `---
+title: Body UUID Test
+spec_id: ${testUuid}
+sync_status: draft
+---
+
+# Body UUID Test
+
+Testing UUID embedding in issue bodies.`
+
+    await createSpecDirectory('009-body-uuid-test', specContent)
+
+    // Mock adapter to capture the issue body
+    let capturedBody: string = ''
+    mockAdapter.push.mockImplementation(async (spec) => {
+      // Simulate what the real adapter does
+      const mainFile = spec.files.get('spec.md')
+      const uuid = mainFile?.frontmatter.spec_id
+
+      if (uuid) {
+        capturedBody = embedUuidInIssueBody('Test issue body content', uuid)
+      }
+
+      return { id: 999, type: 'parent', url: 'test-url' }
+    })
+
+    const specs = await scanner.scanAll()
+    await syncEngine.pushSpec(specs[0])
+
+    // Verify UUID was embedded in the body
+    expect(capturedBody).toContain(`<!-- spec_id: ${testUuid} -->`)
+    expect(capturedBody).toContain('Test issue body content')
+
+    // Verify we can extract the UUID back
+    const extractedUuid = extractUuidFromIssueBody(capturedBody)
+    expect(extractedUuid).toBe(testUuid)
+  })
+
+  test('error handling and recovery', async () => {
+    // Create spec with invalid UUID format
+    const invalidUuidContent = `---
+title: Invalid UUID Test
+spec_id: invalid-uuid-format
+sync_status: draft
+---
+
+# Invalid UUID Test
+
+This spec has an invalid UUID.`
+
+    await createSpecDirectory('010-invalid-uuid-test', invalidUuidContent)
+
+    // Scanner should handle invalid UUID gracefully
+    const specs = await scanner.scanAll()
+    expect(specs).toHaveLength(1)
+
+    const specFile = specs[0].files.get('spec.md')
+
+    // The scanner might either:
+    // 1. Replace the invalid UUID with a valid one, or
+    // 2. Keep the invalid UUID and let validation catch it later
+    // The behavior depends on implementation - both are valid approaches
+    expect(specFile?.frontmatter.spec_id).toBeDefined()
+
+    // If the system validates and replaces invalid UUIDs:
+    if (specFile?.frontmatter.spec_id !== 'invalid-uuid-format') {
+      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      expect(specFile?.frontmatter.spec_id).toMatch(uuidRegex)
+    }
+  })
+})

--- a/plugins/sync/test/migration/uuid-migration.test.ts
+++ b/plugins/sync/test/migration/uuid-migration.test.ts
@@ -1,0 +1,532 @@
+import { promises as fs } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { embedUuidInIssueBody, isValidUuid } from '../../src/adapters/github/uuid-utils'
+import { parseMarkdownWithFrontmatter } from '../../src/core/frontmatter'
+import { SpecScanner } from '../../src/core/scanner'
+
+describe('UUID Migration', () => {
+  let testDir: string
+  let specsDir: string
+  let scanner: SpecScanner
+  let mockAdapter: any
+
+  const validUuid1 = '550e8400-e29b-41d4-a716-446655440000'
+  const validUuid2 = 'f47ac10b-58cc-4372-a567-0e02b2c3d479'
+
+  beforeEach(async () => {
+    // Create temporary test directory
+    testDir = await fs.mkdtemp(path.join(tmpdir(), 'uuid-migration-test-'))
+    specsDir = path.join(testDir, 'specs')
+    await fs.mkdir(specsDir, { recursive: true })
+
+    scanner = new SpecScanner(specsDir)
+
+    // Create mock GitHub adapter
+    mockAdapter = {
+      platform: 'github',
+      searchIssueByUuid: mock(),
+      getIssue: mock(),
+      createIssue: mock(),
+      updateIssue: mock(),
+      push: mock(),
+      getStatus: mock(),
+      authenticate: mock().mockResolvedValue(true),
+    }
+  })
+
+  afterEach(async () => {
+    // Clean up test directory
+    await fs.rm(testDir, { recursive: true, force: true })
+  })
+
+  const createSpecDirectory = async (dirName: string, specContent: string) => {
+    const specDirPath = path.join(specsDir, dirName)
+    await fs.mkdir(specDirPath, { recursive: true })
+    await fs.writeFile(path.join(specDirPath, 'spec.md'), specContent)
+    return specDirPath
+  }
+
+  const readSpecFile = async (dirName: string): Promise<string> => {
+    return fs.readFile(path.join(specsDir, dirName, 'spec.md'), 'utf-8')
+  }
+
+  describe('migrates existing specs without UUID', () => {
+    test('adds UUID to legacy specs with only issue_number', async () => {
+      // Create legacy spec that predates UUID support
+      const legacySpecContent = `---
+title: Legacy Feature
+sync_status: synced
+last_sync: "2024-01-01T10:00:00Z"
+github:
+  issue_number: 123
+  updated_at: "2024-01-01T09:00:00Z"
+---
+
+# Legacy Feature
+
+This spec was created before UUID support was added.
+
+## Details
+
+- Feature A
+- Feature B`
+
+      await createSpecDirectory('001-legacy-feature', legacySpecContent)
+
+      // Scan should automatically add UUID
+      const specs = await scanner.scanAll()
+      expect(specs).toHaveLength(1)
+
+      const spec = specs[0]
+      const specFile = spec.files.get('spec.md')
+
+      // Should now have UUID
+      expect(specFile?.frontmatter.spec_id).toBeDefined()
+      expect(isValidUuid(specFile?.frontmatter.spec_id || '')).toBe(true)
+
+      // Should preserve existing fields
+      expect(specFile?.frontmatter.github?.issue_number).toBe(123)
+      expect(specFile?.frontmatter.sync_status).toBe('synced')
+      expect(specFile?.frontmatter.last_sync).toBe('2024-01-01T10:00:00Z')
+
+      // Should persist UUID to disk
+      const updatedContent = await readSpecFile('001-legacy-feature')
+      expect(updatedContent).toContain('spec_id:')
+      expect(updatedContent).toContain(specFile?.frontmatter.spec_id)
+      expect(updatedContent).toContain('issue_number: 123')
+    })
+
+    test('adds UUID to specs with no frontmatter', async () => {
+      // Create spec with minimal frontmatter
+      const minimalSpecContent = `---
+title: Minimal Feature
+---
+
+# Minimal Feature
+
+This spec has minimal frontmatter.`
+
+      await createSpecDirectory('002-minimal-feature', minimalSpecContent)
+
+      const specs = await scanner.scanAll()
+      const spec = specs[0]
+      const specFile = spec.files.get('spec.md')
+
+      // Should have generated UUID
+      expect(specFile?.frontmatter.spec_id).toBeDefined()
+      expect(isValidUuid(specFile?.frontmatter.spec_id || '')).toBe(true)
+
+      // Should preserve original title
+      expect(specFile?.frontmatter.title).toBe('Minimal Feature')
+
+      // Verify persistence
+      const updatedContent = await readSpecFile('002-minimal-feature')
+      expect(updatedContent).toContain(`spec_id: ${specFile?.frontmatter.spec_id}`)
+    })
+
+    test('adds UUID to specs with empty frontmatter', async () => {
+      // Create spec with only markdown content
+      const contentOnlySpec = `# Content Only Feature
+
+This spec has no frontmatter initially.`
+
+      await createSpecDirectory('003-content-only', contentOnlySpec)
+
+      const specs = await scanner.scanAll()
+      const spec = specs[0]
+      const specFile = spec.files.get('spec.md')
+
+      // Should have generated UUID and basic frontmatter
+      expect(specFile?.frontmatter.spec_id).toBeDefined()
+      expect(isValidUuid(specFile?.frontmatter.spec_id || '')).toBe(true)
+
+      // Verify file structure after migration
+      const updatedContent = await readSpecFile('003-content-only')
+      expect(updatedContent).toContain('---')
+      expect(updatedContent).toContain('spec_id:')
+      expect(updatedContent).toContain('# Content Only Feature')
+    })
+  })
+
+  describe('handles specs with invalid UUIDs', () => {
+    test('replaces malformed UUIDs', async () => {
+      const specWithInvalidUuid = `---
+title: Invalid UUID Feature
+spec_id: "not-a-valid-uuid"
+sync_status: draft
+---
+
+# Invalid UUID Feature
+
+This spec has an invalid UUID format.`
+
+      await createSpecDirectory('004-invalid-uuid', specWithInvalidUuid)
+
+      const specs = await scanner.scanAll()
+      const spec = specs[0]
+      const specFile = spec.files.get('spec.md')
+
+      // Should have a valid UUID now
+      expect(specFile?.frontmatter.spec_id).toBeDefined()
+      expect(specFile?.frontmatter.spec_id).not.toBe('not-a-valid-uuid')
+      expect(isValidUuid(specFile?.frontmatter.spec_id || '')).toBe(true)
+
+      // Verify migration was persisted
+      const updatedContent = await readSpecFile('004-invalid-uuid')
+      expect(updatedContent).not.toContain('not-a-valid-uuid')
+      expect(updatedContent).toContain(`spec_id: ${specFile?.frontmatter.spec_id}`)
+    })
+
+    test('replaces empty UUID fields', async () => {
+      const specWithEmptyUuid = `---
+title: Empty UUID Feature
+spec_id: ""
+sync_status: draft
+---
+
+# Empty UUID Feature`
+
+      await createSpecDirectory('005-empty-uuid', specWithEmptyUuid)
+
+      const specs = await scanner.scanAll()
+      const spec = specs[0]
+      const specFile = spec.files.get('spec.md')
+
+      expect(specFile?.frontmatter.spec_id).toBeDefined()
+      expect(specFile?.frontmatter.spec_id).not.toBe('')
+      expect(isValidUuid(specFile?.frontmatter.spec_id || '')).toBe(true)
+    })
+
+    test('replaces null UUID fields', async () => {
+      const specWithNullUuid = `---
+title: Null UUID Feature
+spec_id: null
+sync_status: draft
+---
+
+# Null UUID Feature`
+
+      await createSpecDirectory('006-null-uuid', specWithNullUuid)
+
+      const specs = await scanner.scanAll()
+      const spec = specs[0]
+      const specFile = spec.files.get('spec.md')
+
+      expect(specFile?.frontmatter.spec_id).toBeDefined()
+      expect(specFile?.frontmatter.spec_id).not.toBeNull()
+      expect(isValidUuid(specFile?.frontmatter.spec_id || '')).toBe(true)
+    })
+  })
+
+  describe('preserves existing valid UUIDs', () => {
+    test('keeps valid existing UUIDs unchanged', async () => {
+      const specWithValidUuid = `---
+title: Valid UUID Feature
+spec_id: ${validUuid1}
+sync_status: synced
+github:
+  issue_number: 456
+---
+
+# Valid UUID Feature
+
+This spec already has a valid UUID.`
+
+      await createSpecDirectory('007-valid-uuid', specWithValidUuid)
+
+      const specs = await scanner.scanAll()
+      const spec = specs[0]
+      const specFile = spec.files.get('spec.md')
+
+      // Should preserve the existing UUID
+      expect(specFile?.frontmatter.spec_id).toBe(validUuid1)
+
+      // File should not be modified
+      const contentAfter = await readSpecFile('007-valid-uuid')
+      expect(contentAfter).toContain(validUuid1)
+    })
+
+    test('preserves UUID across multiple scans', async () => {
+      const specContent = `---
+title: Stability Test
+spec_id: ${validUuid2}
+---
+
+# Stability Test`
+
+      await createSpecDirectory('008-stability-test', specContent)
+
+      // First scan
+      const firstScan = await scanner.scanAll()
+      const firstUuid = firstScan[0].files.get('spec.md')?.frontmatter.spec_id
+
+      // Second scan
+      const secondScan = await scanner.scanAll()
+      const secondUuid = secondScan[0].files.get('spec.md')?.frontmatter.spec_id
+
+      // Third scan with new scanner instance
+      const newScanner = new SpecScanner(specsDir)
+      const thirdScan = await newScanner.scanAll()
+      const thirdUuid = thirdScan[0].files.get('spec.md')?.frontmatter.spec_id
+
+      expect(firstUuid).toBe(validUuid2)
+      expect(secondUuid).toBe(validUuid2)
+      expect(thirdUuid).toBe(validUuid2)
+    })
+  })
+
+  describe('updates remote issues with UUID metadata', () => {
+    test('embeds UUID in existing remote issues', async () => {
+      const specWithIssueNumber = `---
+title: Remote Update Test
+spec_id: ${validUuid1}
+sync_status: synced
+github:
+  issue_number: 789
+---
+
+# Remote Update Test`
+
+      await createSpecDirectory('009-remote-update', specWithIssueNumber)
+
+      // Mock existing remote issue without UUID
+      const existingRemoteIssue = {
+        number: 789,
+        title: 'Remote Update Test',
+        body: 'Existing issue body without UUID metadata',
+        state: 'open',
+        labels: [],
+      }
+
+      mockAdapter.searchIssueByUuid.mockResolvedValue(null) // UUID not found
+      mockAdapter.getIssue.mockResolvedValue(existingRemoteIssue) // Found by issue number
+      mockAdapter.updateIssue.mockImplementation(async (number, updates) => {
+        // Verify UUID is embedded in the updated body
+        expect(updates.body).toContain(`<!-- spec_id: ${validUuid1} -->`)
+        expect(updates.body).toContain('Existing issue body without UUID metadata')
+      })
+
+      const specs = await scanner.scanAll()
+      const spec = specs[0]
+
+      // Simulate push operation
+      mockAdapter.push.mockImplementation(async (specDoc) => {
+        const mainFile = specDoc.files.get('spec.md')
+        const uuid = mainFile?.frontmatter.spec_id
+        const issueNumber = mainFile?.frontmatter.github?.issue_number
+
+        if (uuid && issueNumber) {
+          // This would happen in the real adapter
+          const updatedBody = embedUuidInIssueBody(existingRemoteIssue.body, uuid)
+          await mockAdapter.updateIssue(issueNumber, { body: updatedBody })
+        }
+
+        return { id: 789, type: 'parent', url: 'test-url' }
+      })
+
+      // Push should embed UUID in remote issue
+      await mockAdapter.push(spec)
+
+      expect(mockAdapter.updateIssue).toHaveBeenCalledWith(
+        789,
+        expect.objectContaining({
+          body: expect.stringContaining(`<!-- spec_id: ${validUuid1} -->`),
+        }),
+      )
+    })
+
+    test('creates new issues with UUID metadata from start', async () => {
+      const newSpecContent = `---
+title: New Issue Test
+spec_id: ${validUuid2}
+sync_status: draft
+---
+
+# New Issue Test`
+
+      await createSpecDirectory('010-new-issue', newSpecContent)
+
+      mockAdapter.searchIssueByUuid.mockResolvedValue(null)
+      mockAdapter.createIssue.mockImplementation(async (title, body, _labels) => {
+        // Verify UUID is embedded in new issue body
+        expect(body).toContain(`<!-- spec_id: ${validUuid2} -->`)
+        return 999
+      })
+
+      const specs = await scanner.scanAll()
+      const spec = specs[0]
+
+      // Simulate push operation for new issue
+      mockAdapter.push.mockImplementation(async (specDoc) => {
+        const mainFile = specDoc.files.get('spec.md')
+        const uuid = mainFile?.frontmatter.spec_id
+
+        if (uuid) {
+          const bodyWithUuid = embedUuidInIssueBody('New issue body content', uuid)
+          await mockAdapter.createIssue('New Issue Test', bodyWithUuid, [])
+        }
+
+        return { id: 999, type: 'parent', url: 'test-url' }
+      })
+
+      await mockAdapter.push(spec)
+
+      expect(mockAdapter.createIssue).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining(`<!-- spec_id: ${validUuid2} -->`),
+        expect.any(Array),
+      )
+    })
+  })
+
+  describe('validates migration consistency', () => {
+    test('ensures all migrated specs have valid UUIDs', async () => {
+      // Create multiple specs with various migration scenarios
+      const migrationScenarios = [
+        {
+          name: '011-no-frontmatter',
+          content: '# No Frontmatter\n\nJust content.',
+        },
+        {
+          name: '012-legacy-with-issue',
+          content: `---
+title: Legacy with Issue
+github:
+  issue_number: 111
+---
+# Legacy with Issue`,
+        },
+        {
+          name: '013-invalid-uuid',
+          content: `---
+title: Invalid UUID
+spec_id: invalid
+---
+# Invalid UUID`,
+        },
+        {
+          name: '014-valid-uuid',
+          content: `---
+title: Valid UUID
+spec_id: ${validUuid1}
+---
+# Valid UUID`,
+        },
+      ]
+
+      // Create all test specs
+      for (const scenario of migrationScenarios) {
+        await createSpecDirectory(scenario.name, scenario.content)
+      }
+
+      // Scan all specs
+      const specs = await scanner.scanAll()
+      expect(specs).toHaveLength(4)
+
+      // Validate that all specs now have valid UUIDs
+      for (const spec of specs) {
+        const specFile = spec.files.get('spec.md')
+        expect(specFile?.frontmatter.spec_id).toBeDefined()
+        expect(isValidUuid(specFile?.frontmatter.spec_id || '')).toBe(true)
+
+        // Verify UUID was persisted to disk
+        const dirName = spec.name
+        const persistedContent = await readSpecFile(dirName)
+        expect(persistedContent).toContain('spec_id:')
+        expect(persistedContent).toContain(specFile?.frontmatter.spec_id)
+      }
+
+      // Verify the valid UUID case wasn't changed
+      const validUuidSpec = specs.find(s => s.name === '014-valid-uuid')
+      expect(validUuidSpec?.files.get('spec.md')?.frontmatter.spec_id).toBe(validUuid1)
+    })
+
+    test('handles concurrent migrations safely', async () => {
+      const specContent = `---
+title: Concurrent Test
+---
+# Concurrent Test`
+
+      await createSpecDirectory('015-concurrent-test', specContent)
+
+      // Simulate concurrent scanner operations
+      const scanner1 = new SpecScanner(specsDir)
+      const scanner2 = new SpecScanner(specsDir)
+
+      const [specs1, specs2] = await Promise.all([
+        scanner1.scanAll(),
+        scanner2.scanAll(),
+      ])
+
+      const uuid1 = specs1[0].files.get('spec.md')?.frontmatter.spec_id
+      const uuid2 = specs2[0].files.get('spec.md')?.frontmatter.spec_id
+
+      // Both should have valid UUIDs
+      expect(uuid1).toBeDefined()
+      expect(uuid2).toBeDefined()
+      expect(isValidUuid(uuid1 || '')).toBe(true)
+      expect(isValidUuid(uuid2 || '')).toBe(true)
+
+      // The file on disk should have one consistent UUID
+      const persistedContent = await readSpecFile('015-concurrent-test')
+      const parsedFile = parseMarkdownWithFrontmatter(persistedContent, 'test')
+      expect(isValidUuid(parsedFile.frontmatter.spec_id || '')).toBe(true)
+    })
+
+    test('validates frontmatter integrity after migration', async () => {
+      const complexSpecContent = `---
+title: Complex Migration Test
+sync_status: synced
+issue_type: parent
+auto_sync: true
+last_sync: "2024-01-15T14:30:00Z"
+sync_hash: "abc123def456"
+github:
+  issue_number: 555
+  parent_issue: null
+  updated_at: "2024-01-15T14:25:00Z"
+  labels:
+    - feature
+    - high-priority
+  assignees:
+    - developer1
+    - developer2
+jira:
+  issue_key: "PROJ-123"
+  epic_key: "PROJ-100"
+---
+
+# Complex Migration Test
+
+This spec has complex frontmatter that should be preserved during migration.`
+
+      await createSpecDirectory('016-complex-migration', complexSpecContent)
+
+      const specs = await scanner.scanAll()
+      const spec = specs[0]
+      const specFile = spec.files.get('spec.md')
+
+      // Should have UUID added
+      expect(specFile?.frontmatter.spec_id).toBeDefined()
+      expect(isValidUuid(specFile?.frontmatter.spec_id || '')).toBe(true)
+
+      // Should preserve all existing fields
+      expect(specFile?.frontmatter.title).toBe('Complex Migration Test')
+      expect(specFile?.frontmatter.sync_status).toBe('synced')
+      expect(specFile?.frontmatter.issue_type).toBe('parent')
+      expect(specFile?.frontmatter.auto_sync).toBe(true)
+      expect(specFile?.frontmatter.github?.issue_number).toBe(555)
+      expect(specFile?.frontmatter.github?.labels).toEqual(['feature', 'high-priority'])
+      expect(specFile?.frontmatter.jira?.issue_key).toBe('PROJ-123')
+
+      // Verify file structure is maintained
+      const persistedContent = await readSpecFile('016-complex-migration')
+      expect(persistedContent).toContain('title: Complex Migration Test')
+      expect(persistedContent).toContain('issue_number: 555')
+      expect(persistedContent).toContain('issue_key: "PROJ-123"')
+      expect(persistedContent).toContain('# Complex Migration Test')
+    })
+  })
+})

--- a/plugins/sync/test/performance/uuid-performance.test.ts
+++ b/plugins/sync/test/performance/uuid-performance.test.ts
@@ -1,0 +1,470 @@
+import { promises as fs } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { performance } from 'node:perf_hooks'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import {
+  embedUuidInIssueBody,
+  extractUuidFromIssueBody,
+  hasUuidMetadata,
+  isValidUuid,
+} from '../../src/adapters/github/uuid-utils'
+import { generateSpecId } from '../../src/core/frontmatter'
+import { SpecScanner } from '../../src/core/scanner'
+import { EnhancedMockGitHubClient } from '../mocks/github-client.mock'
+
+describe('UUID Performance Tests', () => {
+  let testDir: string
+  let specsDir: string
+  let scanner: SpecScanner
+  let mockClient: EnhancedMockGitHubClient
+
+  beforeEach(async () => {
+    testDir = await fs.mkdtemp(path.join(tmpdir(), 'uuid-perf-test-'))
+    specsDir = path.join(testDir, 'specs')
+    await fs.mkdir(specsDir, { recursive: true })
+
+    scanner = new SpecScanner(specsDir)
+    mockClient = new EnhancedMockGitHubClient()
+  })
+
+  afterEach(async () => {
+    await fs.rm(testDir, { recursive: true, force: true })
+  })
+
+  const createSpecDirectory = async (dirName: string, specContent: string) => {
+    const specDirPath = path.join(specsDir, dirName)
+    await fs.mkdir(specDirPath, { recursive: true })
+    await fs.writeFile(path.join(specDirPath, 'spec.md'), specContent)
+    return specDirPath
+  }
+
+  const measurePerformance = async <T>(operation: () => Promise<T>): Promise<{ result: T, duration: number }> => {
+    const startTime = performance.now()
+    const result = await operation()
+    const endTime = performance.now()
+    return { result, duration: endTime - startTime }
+  }
+
+  describe('UUID generation performance', () => {
+    test('generates UUIDs efficiently', async () => {
+      const iterations = 1000
+
+      const { duration } = await measurePerformance(async () => {
+        const uuids: string[] = []
+        for (let i = 0; i < iterations; i++) {
+          uuids.push(generateSpecId())
+        }
+        return uuids
+      })
+
+      // Should generate 1000 UUIDs in under 100ms
+      expect(duration).toBeLessThan(100)
+      console.log(`Generated ${iterations} UUIDs in ${duration.toFixed(2)}ms (${(iterations / duration * 1000).toFixed(0)} UUIDs/sec)`)
+    })
+
+    test('validates UUID uniqueness at scale', async () => {
+      const iterations = 10000
+      const uuids = new Set<string>()
+
+      const { result, duration } = await measurePerformance(async () => {
+        for (let i = 0; i < iterations; i++) {
+          const uuid = generateSpecId()
+
+          // Ensure uniqueness
+          if (uuids.has(uuid)) {
+            throw new Error(`Duplicate UUID generated: ${uuid}`)
+          }
+          uuids.add(uuid)
+        }
+        return uuids.size
+      })
+
+      expect(result).toBe(iterations)
+      expect(duration).toBeLessThan(500) // Should complete in under 500ms
+
+      console.log(`Generated ${iterations} unique UUIDs in ${duration.toFixed(2)}ms`)
+    })
+
+    test('UUID format validation performance', async () => {
+      const validUuids = Array.from({ length: 1000 }, () => generateSpecId())
+      const invalidUuids = [
+        'not-a-uuid',
+        '123-456-789',
+        '',
+        'invalid-uuid-format',
+        '550e8400-e29b-41d4-a716-44665544000', // too short
+        '550e8400-e29b-41d4-a716-446655440000-extra', // too long
+      ]
+
+      const { duration: validDuration } = await measurePerformance(async () => {
+        return validUuids.every(uuid => isValidUuid(uuid))
+      })
+
+      const { duration: invalidDuration } = await measurePerformance(async () => {
+        return invalidUuids.every(uuid => !isValidUuid(uuid))
+      })
+
+      // Should validate 1000 UUIDs very quickly
+      expect(validDuration).toBeLessThan(10)
+      expect(invalidDuration).toBeLessThan(5)
+
+      console.log(`Validated ${validUuids.length} valid UUIDs in ${validDuration.toFixed(2)}ms`)
+      console.log(`Validated ${invalidUuids.length} invalid UUIDs in ${invalidDuration.toFixed(2)}ms`)
+    })
+  })
+
+  describe('UUID search performance', () => {
+    test('searches UUIDs efficiently with small datasets', async () => {
+      const numIssues = 100
+      const targetUuid = generateSpecId()
+
+      // Create mock issues with UUIDs
+      const mockIssues = Array.from({ length: numIssues }, (_, i) => ({
+        number: i + 1,
+        title: `Issue ${i + 1}`,
+        uuid: i === 50 ? targetUuid : generateSpecId(), // Target at middle
+        content: `Content for issue ${i + 1}`,
+      }))
+
+      mockClient.addMockIssuesWithUuids(mockIssues)
+
+      const { result, duration } = await measurePerformance(async () => {
+        return await mockClient.searchIssueByUuid(targetUuid)
+      })
+
+      expect(result).toBeDefined()
+      expect(result?.number).toBe(51) // 0-based index 50 + 1
+      expect(duration).toBeLessThan(5) // Should be very fast for small datasets
+
+      console.log(`Found UUID in ${numIssues} issues in ${duration.toFixed(2)}ms`)
+    })
+
+    test('searches UUIDs efficiently with large datasets', async () => {
+      const numIssues = 1000
+      const targetUuid = generateSpecId()
+
+      // Create mock issues with UUIDs
+      const mockIssues = Array.from({ length: numIssues }, (_, i) => ({
+        number: i + 1,
+        title: `Issue ${i + 1}`,
+        uuid: i === 999 ? targetUuid : generateSpecId(), // Target at end (worst case)
+        content: `Content for issue ${i + 1}`,
+      }))
+
+      mockClient.addMockIssuesWithUuids(mockIssues)
+
+      const { result, duration } = await measurePerformance(async () => {
+        return await mockClient.searchIssueByUuid(targetUuid)
+      })
+
+      expect(result).toBeDefined()
+      expect(result?.number).toBe(1000)
+      expect(duration).toBeLessThan(20) // Should still be fast for 1000 issues
+
+      console.log(`Found UUID in ${numIssues} issues in ${duration.toFixed(2)}ms`)
+    })
+
+    test('handles non-existent UUID search efficiently', async () => {
+      const numIssues = 500
+      const nonExistentUuid = generateSpecId()
+
+      // Create mock issues without the target UUID
+      const mockIssues = Array.from({ length: numIssues }, (_, i) => ({
+        number: i + 1,
+        title: `Issue ${i + 1}`,
+        uuid: generateSpecId(),
+        content: `Content for issue ${i + 1}`,
+      }))
+
+      mockClient.addMockIssuesWithUuids(mockIssues)
+
+      const { result, duration } = await measurePerformance(async () => {
+        return await mockClient.searchIssueByUuid(nonExistentUuid)
+      })
+
+      expect(result).toBeNull()
+      expect(duration).toBeLessThan(15) // Should scan all issues quickly
+
+      console.log(`Searched ${numIssues} issues for non-existent UUID in ${duration.toFixed(2)}ms`)
+    })
+  })
+
+  describe('file I/O performance for UUID persistence', () => {
+    test('persists UUIDs to single file efficiently', async () => {
+      const specContent = `---
+title: Performance Test
+sync_status: draft
+---
+
+# Performance Test
+
+Testing UUID persistence performance.`
+
+      await createSpecDirectory('perf-single', specContent)
+
+      const { duration } = await measurePerformance(async () => {
+        const specs = await scanner.scanAll()
+        return specs[0]
+      })
+
+      // Single file should be very fast
+      expect(duration).toBeLessThan(50)
+
+      console.log(`Scanned and persisted UUID for single spec in ${duration.toFixed(2)}ms`)
+    })
+
+    test('persists UUIDs to multiple files efficiently', async () => {
+      const numSpecs = 50
+      const specContent = `---
+title: Performance Test
+sync_status: draft
+---
+
+# Performance Test
+
+Testing UUID persistence performance.`
+
+      // Create multiple spec directories
+      const createPromises = Array.from({ length: numSpecs }, (_, i) =>
+        createSpecDirectory(`perf-${i.toString().padStart(3, '0')}`, specContent))
+      await Promise.all(createPromises)
+
+      const { result, duration } = await measurePerformance(async () => {
+        return await scanner.scanAll()
+      })
+
+      expect(result).toHaveLength(numSpecs)
+      // All specs should have UUIDs generated
+      result.forEach((spec) => {
+        const specFile = spec.files.get('spec.md')
+        expect(specFile?.frontmatter.spec_id).toBeDefined()
+      })
+
+      // Should handle 50 files in reasonable time
+      expect(duration).toBeLessThan(1000) // 1 second
+
+      console.log(`Scanned and persisted UUIDs for ${numSpecs} specs in ${duration.toFixed(2)}ms (${(duration / numSpecs).toFixed(2)}ms per spec)`)
+    })
+
+    test('handles large spec files efficiently', async () => {
+      const largeContent = `---
+title: Large Spec Performance Test
+sync_status: draft
+---
+
+# Large Spec Performance Test
+
+${'This is a large spec with lots of content.\n'.repeat(1000)}
+
+## Section 1
+
+${'More content here.\n'.repeat(500)}
+
+## Section 2
+
+${'Even more content.\n'.repeat(500)}`
+
+      await createSpecDirectory('perf-large', largeContent)
+
+      const { result, duration } = await measurePerformance(async () => {
+        const specs = await scanner.scanAll()
+        return specs[0]
+      })
+
+      expect(result).toBeDefined()
+      const specFile = result.files.get('spec.md')
+      expect(specFile?.frontmatter.spec_id).toBeDefined()
+
+      // Should handle large files efficiently
+      expect(duration).toBeLessThan(100)
+
+      console.log(`Processed large spec file (~50KB) in ${duration.toFixed(2)}ms`)
+    })
+  })
+
+  describe('UUID embedding and extraction performance', () => {
+    test('embeds UUIDs in issue bodies efficiently', async () => {
+      const uuid = generateSpecId()
+      const baseBody = 'This is a test issue body with some content.'
+      const iterations = 1000
+
+      const { duration } = await measurePerformance(async () => {
+        for (let i = 0; i < iterations; i++) {
+          embedUuidInIssueBody(baseBody, uuid)
+        }
+      })
+
+      expect(duration).toBeLessThan(50) // Should be very fast
+      console.log(`Embedded UUID in ${iterations} issue bodies in ${duration.toFixed(2)}ms`)
+    })
+
+    test('extracts UUIDs from issue bodies efficiently', async () => {
+      const uuid = generateSpecId()
+      const bodyWithUuid = embedUuidInIssueBody('Test content', uuid)
+      const iterations = 1000
+
+      const { duration } = await measurePerformance(async () => {
+        for (let i = 0; i < iterations; i++) {
+          const extracted = extractUuidFromIssueBody(bodyWithUuid)
+          if (extracted !== uuid) {
+            throw new Error(`UUID extraction failed: expected ${uuid}, got ${extracted}`)
+          }
+        }
+      })
+
+      expect(duration).toBeLessThan(20) // Should be very fast
+      console.log(`Extracted UUID from ${iterations} issue bodies in ${duration.toFixed(2)}ms`)
+    })
+
+    test('detects UUID metadata efficiently', async () => {
+      const uuid = generateSpecId()
+      const bodyWithUuid = embedUuidInIssueBody('Test content', uuid)
+      const bodyWithoutUuid = 'Test content without UUID'
+      const iterations = 500
+
+      const { duration } = await measurePerformance(async () => {
+        for (let i = 0; i < iterations; i++) {
+          const hasUuid1 = hasUuidMetadata(bodyWithUuid)
+          const hasUuid2 = hasUuidMetadata(bodyWithoutUuid)
+
+          if (!hasUuid1 || hasUuid2) {
+            throw new Error('UUID metadata detection failed')
+          }
+        }
+      })
+
+      expect(duration).toBeLessThan(15)
+      console.log(`Detected UUID metadata in ${iterations * 2} bodies in ${duration.toFixed(2)}ms`)
+    })
+
+    test('handles very large issue bodies efficiently', async () => {
+      const uuid = generateSpecId()
+      const largeContent = 'A'.repeat(100000) // 100KB content
+
+      const { result: embedResult, duration: embedDuration } = await measurePerformance(async () => {
+        return embedUuidInIssueBody(largeContent, uuid)
+      })
+
+      const { result: extractResult, duration: extractDuration } = await measurePerformance(async () => {
+        return extractUuidFromIssueBody(embedResult)
+      })
+
+      expect(extractResult).toBe(uuid)
+      expect(embedDuration).toBeLessThan(10) // Should be fast even for large content
+      expect(extractDuration).toBeLessThan(10)
+
+      console.log(`Embedded UUID in 100KB body in ${embedDuration.toFixed(2)}ms`)
+      console.log(`Extracted UUID from 100KB body in ${extractDuration.toFixed(2)}ms`)
+    })
+  })
+
+  describe('concurrent operations performance', () => {
+    test('handles concurrent UUID generation efficiently', async () => {
+      const concurrency = 10
+      const iterations = 100
+
+      const { duration } = await measurePerformance(async () => {
+        const promises = Array.from({ length: concurrency }, async () => {
+          const uuids = new Set<string>()
+          for (let i = 0; i < iterations; i++) {
+            uuids.add(generateSpecId())
+          }
+          return uuids
+        })
+
+        const results = await Promise.all(promises)
+
+        // Verify no duplicates across all concurrent operations
+        const allUuids = new Set<string>()
+        results.forEach((uuidSet) => {
+          uuidSet.forEach((uuid) => {
+            if (allUuids.has(uuid)) {
+              throw new Error(`Duplicate UUID found in concurrent generation: ${uuid}`)
+            }
+            allUuids.add(uuid)
+          })
+        })
+
+        return allUuids.size
+      })
+
+      const totalGenerated = concurrency * iterations
+      expect(duration).toBeLessThan(200) // Should handle concurrent generation well
+
+      console.log(`Generated ${totalGenerated} UUIDs concurrently (${concurrency} threads) in ${duration.toFixed(2)}ms`)
+    })
+
+    test('handles concurrent spec scanning efficiently', async () => {
+      const numSpecs = 20
+      const specContent = `---
+title: Concurrent Test
+sync_status: draft
+---
+
+# Concurrent Test
+
+Testing concurrent scanning.`
+
+      // Create specs
+      await Promise.all(
+        Array.from({ length: numSpecs }, (_, i) =>
+          createSpecDirectory(`concurrent-${i.toString().padStart(2, '0')}`, specContent)),
+      )
+
+      const { result, duration } = await measurePerformance(async () => {
+        // Run multiple scanners concurrently
+        const scanners = Array.from({ length: 3 }, () => new SpecScanner(specsDir))
+        const scanPromises = scanners.map(s => s.scanAll())
+
+        const results = await Promise.all(scanPromises)
+
+        // All scanners should find the same number of specs
+        results.forEach((specs) => {
+          expect(specs).toHaveLength(numSpecs)
+        })
+
+        return results[0]
+      })
+
+      expect(result).toHaveLength(numSpecs)
+      expect(duration).toBeLessThan(500) // Should handle concurrent scanning
+
+      console.log(`Scanned ${numSpecs} specs with 3 concurrent scanners in ${duration.toFixed(2)}ms`)
+    })
+  })
+
+  describe('memory usage optimization', () => {
+    test('maintains reasonable memory usage during bulk operations', async () => {
+      const numIssues = 2000
+      const initialMemory = process.memoryUsage().heapUsed
+
+      // Create a large number of mock issues
+      const mockIssues = Array.from({ length: numIssues }, (_, i) => ({
+        number: i + 1,
+        title: `Bulk Issue ${i + 1}`,
+        uuid: generateSpecId(),
+        content: `Content for bulk issue ${i + 1}`.repeat(10), // Make content larger
+      }))
+
+      mockClient.addMockIssuesWithUuids(mockIssues)
+
+      // Perform multiple searches
+      const searchPromises = Array.from({ length: 100 }, async (_, i) => {
+        const targetIssue = mockIssues[i * 20] // Search for every 20th issue
+        return await mockClient.searchIssueByUuid(targetIssue.uuid)
+      })
+
+      await Promise.all(searchPromises)
+
+      const finalMemory = process.memoryUsage().heapUsed
+      const memoryIncrease = finalMemory - initialMemory
+      const memoryIncreaseMB = memoryIncrease / 1024 / 1024
+
+      // Memory increase should be reasonable (less than 50MB for this test)
+      expect(memoryIncreaseMB).toBeLessThan(50)
+
+      console.log(`Memory increase: ${memoryIncreaseMB.toFixed(2)}MB for ${numIssues} issues and 100 searches`)
+    })
+  })
+})

--- a/plugins/sync/test/schemas/spec-uuid.test.ts
+++ b/plugins/sync/test/schemas/spec-uuid.test.ts
@@ -1,0 +1,377 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  RequiredSpecIdFrontmatterSchema,
+  safeParseFrontmatter,
+  safeParseSpecId,
+  SpecFileFrontmatterSchema,
+  validateFrontmatter,
+  validateFrontmatterWithSpecId,
+  validateSpecIdOnly,
+} from '../../src/schemas/spec'
+
+describe('Schema UUID Validation', () => {
+  const validUuidV4 = '123e4567-e89b-42d3-a456-426614174000'
+  const validUuidV4Alt = 'f47ac10b-58cc-4372-a567-0e02b2c3d479'
+  const invalidUuid = 'not-a-uuid'
+  const malformedUuid = '550e8400-e29b-41d4-a716-44665544000' // missing digit
+  const wrongVersionUuid = '550e8400-e29b-31d4-a716-446655440000' // version 3
+  const emptyString = ''
+
+  describe('validateSpecIdOnly', () => {
+    test('validates correct UUID v4 format', () => {
+      expect(validateSpecIdOnly(validUuidV4)).toBe(validUuidV4)
+      expect(validateSpecIdOnly(validUuidV4Alt)).toBe(validUuidV4Alt)
+    })
+
+    test('accepts uppercase UUIDs', () => {
+      const uppercaseUuid = 'F47AC10B-58CC-4372-A567-0E02B2C3D479'
+      expect(validateSpecIdOnly(uppercaseUuid)).toBe(uppercaseUuid)
+    })
+
+    test('throws ZodError for invalid UUIDs', () => {
+      expect(() => validateSpecIdOnly(invalidUuid)).toThrow()
+      expect(() => validateSpecIdOnly(malformedUuid)).toThrow()
+      expect(() => validateSpecIdOnly(emptyString)).toThrow()
+      expect(() => validateSpecIdOnly(wrongVersionUuid)).toThrow()
+    })
+
+    test('throws ZodError for non-string input', () => {
+      expect(() => validateSpecIdOnly(123)).toThrow()
+      expect(() => validateSpecIdOnly(null)).toThrow()
+      expect(() => validateSpecIdOnly(undefined)).toThrow()
+      expect(() => validateSpecIdOnly({})).toThrow()
+    })
+  })
+
+  describe('safeParseSpecId', () => {
+    test('returns success for valid UUIDs', () => {
+      const result = safeParseSpecId(validUuidV4)
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data).toBe(validUuidV4)
+      }
+    })
+
+    test('returns error for invalid UUIDs', () => {
+      const results = [
+        safeParseSpecId(invalidUuid),
+        safeParseSpecId(malformedUuid),
+        safeParseSpecId(emptyString),
+        safeParseSpecId(wrongVersionUuid),
+        safeParseSpecId(123),
+        safeParseSpecId(null),
+        safeParseSpecId(undefined),
+      ]
+
+      results.forEach((result) => {
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error).toBeDefined()
+        }
+      })
+    })
+
+    test('provides detailed error messages', () => {
+      const result = safeParseSpecId(invalidUuid)
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues).toBeDefined()
+        expect(result.error.issues.length).toBeGreaterThan(0)
+      }
+    })
+  })
+
+  describe('SpecFileFrontmatterSchema with UUID', () => {
+    test('validates complete frontmatter with valid UUID', () => {
+      const frontmatter = {
+        spec_id: validUuidV4,
+        sync_hash: 'abc123def456',
+        last_sync: '2023-01-01T00:00:00Z',
+        sync_status: 'draft' as const,
+        issue_type: 'parent' as const,
+        auto_sync: true,
+        github: {
+          issue_number: 123,
+          labels: ['feature'],
+        },
+      }
+
+      const result = SpecFileFrontmatterSchema.parse(frontmatter)
+      expect(result.spec_id).toBe(validUuidV4)
+      expect(result.sync_status).toBe('draft')
+    })
+
+    test('validates frontmatter without spec_id (optional)', () => {
+      const frontmatter = {
+        sync_status: 'draft' as const,
+        auto_sync: true,
+      }
+
+      const result = SpecFileFrontmatterSchema.parse(frontmatter)
+      expect(result.spec_id).toBeUndefined()
+      expect(result.sync_status).toBe('draft')
+    })
+
+    test('rejects frontmatter with invalid UUID', () => {
+      const frontmatter = {
+        spec_id: invalidUuid,
+        sync_status: 'draft' as const,
+      }
+
+      expect(() => SpecFileFrontmatterSchema.parse(frontmatter)).toThrow()
+    })
+
+    test('rejects frontmatter with non-v4 UUID', () => {
+      const frontmatter = {
+        spec_id: wrongVersionUuid,
+        sync_status: 'draft' as const,
+      }
+
+      expect(() => SpecFileFrontmatterSchema.parse(frontmatter)).toThrow()
+    })
+
+    test('safe parsing returns error for invalid UUID', () => {
+      const frontmatter = {
+        spec_id: invalidUuid,
+        sync_status: 'draft' as const,
+      }
+
+      const result = safeParseFrontmatter(frontmatter)
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues.some(issue =>
+          issue.path.includes('spec_id'),
+        )).toBe(true)
+      }
+    })
+  })
+
+  describe('RequiredSpecIdFrontmatterSchema', () => {
+    test('validates frontmatter with required valid UUID', () => {
+      const frontmatter = {
+        spec_id: validUuidV4,
+        sync_status: 'draft' as const,
+      }
+
+      const result = RequiredSpecIdFrontmatterSchema.parse(frontmatter)
+      expect(result.spec_id).toBe(validUuidV4)
+    })
+
+    test('rejects frontmatter without spec_id', () => {
+      const frontmatter = {
+        sync_status: 'draft' as const,
+      }
+
+      expect(() => RequiredSpecIdFrontmatterSchema.parse(frontmatter)).toThrow()
+    })
+
+    test('rejects frontmatter with invalid spec_id', () => {
+      const frontmatter = {
+        spec_id: invalidUuid,
+        sync_status: 'draft' as const,
+      }
+
+      expect(() => RequiredSpecIdFrontmatterSchema.parse(frontmatter)).toThrow()
+    })
+
+    test('rejects frontmatter with empty spec_id', () => {
+      const frontmatter = {
+        spec_id: '',
+        sync_status: 'draft' as const,
+      }
+
+      expect(() => RequiredSpecIdFrontmatterSchema.parse(frontmatter)).toThrow()
+    })
+  })
+
+  describe('validateFrontmatterWithSpecId', () => {
+    test('validates and returns frontmatter with valid spec_id', () => {
+      const frontmatter = {
+        spec_id: validUuidV4,
+        sync_status: 'draft' as const,
+        auto_sync: true,
+      }
+
+      const result = validateFrontmatterWithSpecId(frontmatter)
+      expect(result.spec_id).toBe(validUuidV4)
+      expect(result.sync_status).toBe('draft')
+      expect(result.auto_sync).toBe(true)
+    })
+
+    test('throws error when spec_id is missing', () => {
+      const frontmatter = {
+        sync_status: 'draft' as const,
+      }
+
+      expect(() => validateFrontmatterWithSpecId(frontmatter)).toThrow('spec_id is required but was not provided')
+    })
+
+    test('throws ZodError when spec_id is invalid', () => {
+      const frontmatter = {
+        spec_id: invalidUuid,
+        sync_status: 'draft' as const,
+      }
+
+      expect(() => validateFrontmatterWithSpecId(frontmatter)).toThrow()
+    })
+
+    test('throws error when spec_id is empty string', () => {
+      const frontmatter = {
+        spec_id: '',
+        sync_status: 'draft' as const,
+      }
+
+      expect(() => validateFrontmatterWithSpecId(frontmatter)).toThrow()
+    })
+
+    test('type safety - result has guaranteed spec_id', () => {
+      const frontmatter = {
+        spec_id: validUuidV4,
+        sync_status: 'draft' as const,
+      }
+
+      const result = validateFrontmatterWithSpecId(frontmatter)
+
+      // TypeScript should know that result.spec_id is string, not string | undefined
+      expect(typeof result.spec_id).toBe('string')
+      expect(result.spec_id.length).toBe(36) // No need for optional chaining
+    })
+  })
+
+  describe('error message quality', () => {
+    test('provides helpful error messages for invalid UUIDs', () => {
+      const testCases = [
+        { input: 'not-a-uuid', expectedInMessage: 'Invalid UUID format' },
+        { input: '123', expectedInMessage: 'Invalid UUID format' },
+        { input: malformedUuid, expectedInMessage: 'UUID must be a valid v4 UUID format' },
+        { input: wrongVersionUuid, expectedInMessage: 'UUID must be a valid v4 UUID format' },
+      ]
+
+      testCases.forEach(({ input, expectedInMessage }) => {
+        try {
+          validateSpecIdOnly(input)
+          fail(`Expected validation to throw for input: ${input}`)
+        }
+        catch (error: any) {
+          expect(error.message).toContain(expectedInMessage)
+        }
+      })
+    })
+
+    test('provides context in frontmatter validation errors', () => {
+      const frontmatter = {
+        spec_id: invalidUuid,
+        sync_status: 'draft' as const,
+      }
+
+      const result = safeParseFrontmatter(frontmatter)
+      expect(result.success).toBe(false)
+
+      if (!result.success) {
+        const specIdError = result.error.issues.find(issue =>
+          issue.path.includes('spec_id'),
+        )
+        expect(specIdError).toBeDefined()
+        expect(specIdError?.message).toContain('Invalid UUID format')
+      }
+    })
+  })
+
+  describe('performance with various UUID formats', () => {
+    test('handles many UUID validations efficiently', () => {
+      const uuids = Array.from({ length: 1000 }, (_, i) =>
+        `${i.toString().padStart(8, '0')}-1234-4567-8901-${(i * 2).toString().padStart(12, '0')}`)
+
+      const startTime = Date.now()
+
+      uuids.forEach((uuid) => {
+        const result = safeParseSpecId(uuid)
+        expect(result.success).toBe(true)
+      })
+
+      const endTime = Date.now()
+      expect(endTime - startTime).toBeLessThan(1000) // Should be fast
+    })
+
+    test('validates complex frontmatter objects efficiently', () => {
+      const complexFrontmatter = {
+        spec_id: validUuidV4,
+        sync_hash: 'a'.repeat(12),
+        last_sync: '2023-01-01T00:00:00.000Z',
+        sync_status: 'synced' as const,
+        issue_type: 'parent' as const,
+        auto_sync: true,
+        github: {
+          issue_number: 123,
+          parent_issue: 456,
+          updated_at: '2023-01-01T00:00:00.000Z',
+          labels: Array.from({ length: 10 }, (_, i) => `label-${i}`),
+          assignees: Array.from({ length: 5 }, (_, i) => `user-${i}`),
+          milestone: 789,
+        },
+        jira: {
+          issue_key: 'PROJ-123',
+          epic_key: 'PROJ-100',
+          issue_type: 'Story',
+          updated: '2023-01-01T00:00:00.000Z',
+        },
+        asana: {
+          task_gid: '1234567890',
+          project_gid: '9876543210',
+          parent_task: '5555555555',
+          modified_at: '2023-01-01T00:00:00.000Z',
+        },
+      }
+
+      const startTime = Date.now()
+
+      for (let i = 0; i < 100; i++) {
+        const result = validateFrontmatter(complexFrontmatter)
+        expect(result.spec_id).toBe(validUuidV4)
+      }
+
+      const endTime = Date.now()
+      expect(endTime - startTime).toBeLessThan(500) // Should be fast
+    })
+  })
+
+  describe('integration scenarios', () => {
+    test('round-trip validation maintains data integrity', () => {
+      const originalFrontmatter = {
+        spec_id: validUuidV4,
+        sync_hash: 'abc123def456',
+        sync_status: 'synced' as const,
+        github: { issue_number: 123 },
+      }
+
+      // Validate and parse
+      const validated = validateFrontmatter(originalFrontmatter)
+
+      // Validate spec_id specifically
+      const specId = validateSpecIdOnly(validated.spec_id!)
+
+      // Ensure the data is unchanged
+      expect(validated).toEqual(originalFrontmatter)
+      expect(specId).toBe(validUuidV4)
+    })
+
+    test('schema evolution compatibility', () => {
+      // Simulate frontmatter with extra properties (future compatibility)
+      const futureCompatibleFrontmatter = {
+        spec_id: validUuidV4,
+        sync_status: 'draft' as const,
+        future_property: 'should be ignored',
+        nested_future: {
+          property: 'also ignored',
+        },
+      }
+
+      // Current schema should accept and ignore unknown properties
+      const result = SpecFileFrontmatterSchema.parse(futureCompatibleFrontmatter)
+      expect(result.spec_id).toBe(validUuidV4)
+      expect(result.sync_status).toBe('draft')
+      // Future properties should be stripped out by Zod
+      expect((result as any).future_property).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
- Add UUID generation for spec.md files without existing spec_id.
- Ensure existing UUIDs are preserved during scans.
- Embed UUID in GitHub issue bodies for better tracking.
- Update scanning logic to prioritize UUID over issue number for issue matching.